### PR TITLE
Fixed recipient_groups allowedRolesAndUsers permissions through batch actions

### DIFF
--- a/imio/dms/mail/browser/batchactions.py
+++ b/imio/dms/mail/browser/batchactions.py
@@ -94,6 +94,14 @@ class RecipientGroupBatchActionForm(BaseARUOBatchActionForm):
     def _remove_vocabulary(self):
         return u"collective.contact.plonegroup.organization_services"
 
+    def _apply(self, **data):
+        updated = super(RecipientGroupBatchActionForm, self)._apply(**data)
+        for obj in updated:
+            obj.reindexObject(idxs=["allowedRolesAndUsers"])
+            for child in obj.objectValues():
+                child.reindexObject(idxs=["allowedRolesAndUsers"])
+        return updated
+
 
 class AssignedUserBatchActionForm(aubaf):
 


### PR DESCRIPTION
Est-ce nécessaire de faire une récursion sur tous les enfants ou reindexer tous les enfants directs est suffisant ? Pour l'instant, une fiche courrier n'a que des enfants directs mais ça pourrait peut-être changer dans le futur

Est-ce bien de surcharger la méthode _apply ?