### PR TITLE
Display files table in DMS mail edit mode

### DIFF
--- a/imio/dms/mail/browser/table.py
+++ b/imio/dms/mail/browser/table.py
@@ -4,6 +4,7 @@ from collective.dms.basecontent.browser.listing import VersionsTable
 from collective.dms.basecontent.browser.listing import VersionsTitleColumn
 from collective.iconifiedcategory import utils as ic_utils
 from collective.iconifiedcategory.browser.tabview import CategorizedContent
+from collective.iconifiedcategory.browser.tabview import IconClickableColumn
 from collective.task import _ as _task
 from html import escape  # noqa F401
 from imio.dms.mail import _
@@ -122,6 +123,18 @@ class BaseVersionsTable(VersionsTable):
                 ][::-1])
             self._v_stored_values = data
         return self._v_stored_values
+
+    def is_edit_mode(self):
+        view_name = self.request.get('ACTUAL_URL', '').split('/')[-1]
+        return view_name in ('edit', '@@edit')
+
+    def setUpColumns(self):
+        """When in edit view, removes actionnable columns"""
+        columns = super(BaseVersionsTable, self).setUpColumns()
+        if self.is_edit_mode():
+            actionnable_cols = ["action-column"]
+            columns = [col for col in columns if col.__name__ not in actionnable_cols and not isinstance(col, IconClickableColumn)]
+        return columns
 
 
 class IMVersionsTable(BaseVersionsTable):

--- a/imio/dms/mail/browser/table.py
+++ b/imio/dms/mail/browser/table.py
@@ -103,6 +103,17 @@ class AssignedGroupColumn(Column):
         return escape(safe_unicode(voc.getTerm(item.assigned_group).title))
 
 
+def _disable_icon_clickable(col):
+    """Render IconClickableColumn icon as a non-clickable <span>"""
+
+    def renderCell(content):
+        css = col.css_class(content).replace(' editable', '')
+        return u'<span class="iconified-action{0}" alt="{1}" title="{1}"></span>'.format(
+            css, col.alt(content)
+        )
+    col.renderCell = renderCell
+
+
 class BaseVersionsTable(VersionsTable):
     portal_types = []
 
@@ -125,15 +136,20 @@ class BaseVersionsTable(VersionsTable):
         return self._v_stored_values
 
     def is_edit_mode(self):
-        view_name = self.request.get('ACTUAL_URL', '').split('/')[-1]
+        """Is the table rendered when we are editing content ?"""
+        actual_url = self.request.get('ACTUAL_URL', '')
+        view_name = actual_url.split('?', 1)[0].rstrip('/').split('/')[-1]
         return view_name in ('edit', '@@edit')
 
     def setUpColumns(self):
-        """When in edit view, removes actionnable columns"""
+        """When in edit view, removes useless columns and disables IconClickableColumn links"""
         columns = super(BaseVersionsTable, self).setUpColumns()
         if self.is_edit_mode():
-            actionnable_cols = ["action-column"]
-            columns = [col for col in columns if col.__name__ not in actionnable_cols and not isinstance(col, IconClickableColumn)]
+            useless_cols = ("filesize-column", "action-column")
+            columns = [col for col in columns if col.__name__ not in useless_cols]
+            for col in columns:
+                if isinstance(col, IconClickableColumn):
+                    _disable_icon_clickable(col)
         return columns
 
 

--- a/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
+++ b/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
@@ -153,7 +153,7 @@ body.template-view.portaltype-dmsoutgoingmail #form-widgets-ISigningBehavior-esi
 
 .template-dmsdocument-edit #fieldset-versions {
     width: 65% !important;
-    padding-top: 4em;
+    margin-top: 6em;
 }
 
 #all-fields, .template-dmsdocument-edit #content-core #fieldset-default {
@@ -236,7 +236,6 @@ body.template-view.portaltype-dmsoutgoingmail #form-widgets-ISigningBehavior-esi
     margin-top: 3em;
 }
 
-.template-dmsdocument-edit #fieldset-versions table,
 .template-dmsdocument-edit #content-core > p.discreet,
 .template-dmsdocument-edit #content-core form.kssattr-formname-dmsdocument-edit ul.formTabs {
     display: None;

--- a/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
+++ b/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
@@ -153,7 +153,7 @@ body.template-view.portaltype-dmsoutgoingmail #form-widgets-ISigningBehavior-esi
 
 .template-dmsdocument-edit #fieldset-versions {
     width: 65% !important;
-    margin-top: 6em;
+    margin-top: 5em;
 }
 
 #all-fields, .template-dmsdocument-edit #content-core #fieldset-default {
@@ -233,7 +233,7 @@ body.template-view.portaltype-dmsoutgoingmail #form-widgets-ISigningBehavior-esi
 
 .template-dmsdocument-edit #DV-container {
     width: 100% !important;
-    margin-top: 3em;
+    margin-top: 0;
 }
 
 .template-dmsdocument-edit #content-core > p.discreet,

--- a/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
+++ b/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
@@ -536,12 +536,46 @@ body.template-facetednavigation_view.portaltype-classificationsubfolder #content
     text-align: center;
 }
 
+/* original css with span replacing a in edit mode */
+#content .iconified-listing td.iconified-print span,
+#content .iconified-listing td.iconified-signed span,
+#content .iconified-listing td.iconified-approved span {
+    font-family: 'Font Awesome 5 Free';
+    font-size: 110%;
+    font-weight: bold;
+}
+#content .iconified-listing td.iconified-print span::before {
+    content: "\f02f";
+}
+#content .iconified-listing td.iconified-approved span::before {
+    content: "\f00c";
+}
+#content .iconified-listing td.iconified-print span,
+#content .iconified-listing td.iconified-signed span,
+#content .iconified-listing td.iconified-approved span {
+    color: #EA0000;
+}
+#content .iconified-listing td.iconified-print span.active,
+#content .iconified-listing td.iconified-signed span.active,
+#content .iconified-listing td.iconified-approved span.active {
+    color: #75ad0a;
+}
+#content .iconified-listing td.iconified-print span.deactivated,
+#content .iconified-listing td.iconified-approved span.deactivated {
+    color: silver;
+}
+/* end */
+
 #content .iconified-listing td.iconified-approved a.to-approve::before,
-#content .iconified-listing td.iconified-signed a.deactivated::before {
+#content .iconified-listing td.iconified-approved span.to-approve::before,
+#content .iconified-listing td.iconified-signed a.deactivated::before,
+#content .iconified-listing td.iconified-signed span.deactivated::before {
     content: "\f204";  /* toggle-off */
 }
 #content .iconified-listing td.iconified-approved a.to-approve,
-#content .iconified-listing td.iconified-signed a.deactivated {
+#content .iconified-listing td.iconified-approved span.to-approve,
+#content .iconified-listing td.iconified-signed a.deactivated,
+#content .iconified-listing td.iconified-signed span.deactivated {
     color: #999;
 }
 #content .iconified-listing td.iconified-approved a.to-approve:hover,
@@ -550,28 +584,34 @@ body.template-facetednavigation_view.portaltype-classificationsubfolder #content
 }
 
 #content .iconified-listing td.iconified-approved a.active.to-approve::before,
-#content .iconified-listing td.iconified-signed a::before {
+#content .iconified-listing td.iconified-approved span.active.to-approve::before,
+#content .iconified-listing td.iconified-signed a::before,
+#content .iconified-listing td.iconified-signed span::before {
     content: "\f205";  /* toggle-on */
 }
-#content .iconified-listing td.iconified-approved a.active.to-approve {
+#content .iconified-listing td.iconified-approved a.active.to-approve,
+#content .iconified-listing td.iconified-approved span.active.to-approve {
     color: #EA0000;
 }
 #content .iconified-listing td.iconified-approved a.active.to-approve:hover {
     color: #B50000 !important;
 }
 
-#content .iconified-listing td.iconified-signed a.active::before {
+#content .iconified-listing td.iconified-signed a.active::before,
+#content .iconified-listing td.iconified-signed span.active::before {
     content: "\f044";  /* pen-to-square */
 }
 
-#content .iconified-listing td.iconified-approved a.cant-approve::before
+#content .iconified-listing td.iconified-approved a.cant-approve::before,
+#content .iconified-listing td.iconified-approved span.cant-approve::before
 {
   content: "\f254";  /* hourglass */
   color: black;
   font-weight: initial;
 }
 
-#content .iconified-listing td.iconified-approved a.waiting::before
+#content .iconified-listing td.iconified-approved a.waiting::before,
+#content .iconified-listing td.iconified-approved span.waiting::before
 {
   /*content: "\f251";  /* hourglass-start */
   content: "\f254";  /* hourglass */
@@ -579,12 +619,14 @@ body.template-facetednavigation_view.portaltype-classificationsubfolder #content
   font-weight: initial;
 }
 
-#content .iconified-listing td.iconified-approved a.partially-approved::before {
+#content .iconified-listing td.iconified-approved a.partially-approved::before,
+#content .iconified-listing td.iconified-approved span.partially-approved::before {
   content: "\f252";  /* hourglass-half */
   color: #FFB627;
 }
 
-#content .iconified-listing td.iconified-approved a.totally-approved::before {
+#content .iconified-listing td.iconified-approved a.totally-approved::before,
+#content .iconified-listing td.iconified-approved span.totally-approved::before {
   content: "\f560";  /* check-double */
   color: #75ad0a;
 }


### PR DESCRIPTION
ça a été demandé par Lasne et Seraing. Mais je vois que cette table a été expressément masquée en mode édition. Je me demande donc quelles étaient les raisons de l'avoir masquée à la base ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing and removed an unnecessary top offset in the document edit view for a cleaner layout.
  * Updated status icon rendering to use non-clickable spans and refreshed icon mappings for consistent visuals.

* **Bug Fixes**
  * Ensure the versions table is visible in edit mode by removing an overly strict hide rule.
  * Hide action and icon columns while editing to simplify the versions list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->