### PR TITLE
Updated ToPrint wfa to work with esign

### DIFF
--- a/imio/dms/mail/adapters.py
+++ b/imio/dms/mail/adapters.py
@@ -37,6 +37,7 @@ from imio.dms.mail.interfaces import IOMApproval
 from imio.dms.mail.utils import back_or_again_state
 from imio.dms.mail.utils import get_allowed_omf_content_types
 from imio.dms.mail.utils import get_dms_config
+from imio.dms.mail.utils import get_post_approval_transition
 from imio.dms.mail.utils import get_scan_id
 from imio.dms.mail.utils import highest_review_level
 from imio.dms.mail.utils import is_dv_conv_in_error
@@ -1496,7 +1497,7 @@ class OMApprovalAdapter(object):
                 self.approve_file(
                     uuidToObject(fuid, unrestricted=True),
                     backup_approval["approved_by"],
-                    transition="propose_to_be_signed",
+                    transition=True,
                     c_a=signer_index,
                 )
                 approved_on = backup_approval["approved_on"]
@@ -1598,13 +1599,13 @@ class OMApprovalAdapter(object):
             return False
         return True
 
-    def approve_file(self, afile, userid, values=None, transition=None, c_a=None):
+    def approve_file(self, afile, userid, values=None, transition=False, c_a=None):
         """Approve the current file.
 
         :param afile: file to approve
         :param userid: current user id
         :param values: optional dict to update
-        :param transition: optional transition to do after approval
+        :param transition: whether the post approval transition should be triggered if all files are approved
         :param c_a: overrides current approval number to mark approval, if None uses current_nb
         :return: approval status bool (True=ok), reload bool (True=reload page)
         """
@@ -1631,7 +1632,6 @@ class OMApprovalAdapter(object):
             "approve_file",
             "mail={} file={} signer={} approver={}".format(self.context.UID(), f_uid, self.signers[c_a], userid)
         )
-        pc = getToolByName(self.context, "portal_catalog")
         if self.is_file_approved(f_uid):
             afile.approved = True
             if values is not None:
@@ -1654,6 +1654,7 @@ class OMApprovalAdapter(object):
             return True, True
         message = u"The file '${file}' has been approved by ${user}. "
         c_a = self.current_nb  # current approval
+        pc = getToolByName(self.context, "portal_catalog")
         if c_a is not None and 0 <= c_a < len(self.annot["approval"]):
             for i in range(len(self.files_uids)):
                 if self.annot["approval"][c_a][i]["status"] != "a":
@@ -1702,7 +1703,8 @@ class OMApprovalAdapter(object):
                 # must use the following ?
                 # do_next_transition(self.context, self.context.portal_type, state="to_approve")
                 with api.env.adopt_roles(["Reviewer"]):
-                    do_transitions(self.context, [transition])
+                    post_approval_transition = get_post_approval_transition(self.context)
+                    do_transitions(self.context, [post_approval_transition])
                     # api.portal.show_message(
                     #     message=_(u"The mail has been automatically transitioned to state '${state}'.",
                     #               mapping={"state": self.context.portal_workflow.getInfoFor(self.context,

--- a/imio/dms/mail/browser/iconified_category.py
+++ b/imio/dms/mail/browser/iconified_category.py
@@ -175,7 +175,7 @@ class ApprovedChangeView(BaseApprovedChangeView):
                         afile=self.context,
                         userid=self.userid,
                         values=values,
-                        transition="propose_to_be_signed",
+                        transition=True,
                     )
                     status = int(ret)
                     values["approved"] = ret

--- a/imio/dms/mail/browser/views.py
+++ b/imio/dms/mail/browser/views.py
@@ -604,7 +604,7 @@ class ApprovalTableView(BrowserView):
 
             # Approve only now to avoid unwanted transition
             for fobj, signer, i_signer in to_approve:
-                approval.approve_file(fobj, signer, c_a=i_signer, transition="propose_to_be_signed")
+                approval.approve_file(fobj, signer, c_a=i_signer, transition=True)
 
             IStatusMessage(self.request).addStatusMessage(_(u"Changes saved."), type="info")
             self.request.response.redirect(self.context.absolute_url())

--- a/imio/dms/mail/dmsmail.py
+++ b/imio/dms/mail/dmsmail.py
@@ -907,12 +907,12 @@ class ImioDmsOutgoingMailWfConditionsAdapter(object):
         """Used in guard expression for to_print and back_to_print transitions."""
         if self.context.esign:
             return False
+        if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
+            return False
         brains = self.context.portal_catalog.unrestrictedSearchResults(
-            portal_type="dmsommainfile", path="/".join(self.context.getPhysicalPath())
+            portal_type="dmsommainfile", path="/".join(self.context.getPhysicalPath()), b_size=1
         )
         if not bool(brains):
-            return False
-        if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
             return False
         return True
 
@@ -920,12 +920,12 @@ class ImioDmsOutgoingMailWfConditionsAdapter(object):
 
     def can_be_signed(self):
         """Used in guard expression for to_be_signed transition."""
+        if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
+            return False
         brains = self.context.portal_catalog.unrestrictedSearchResults(
-            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath())
+            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath()), b_size=1
         )
         if not bool(brains):
-            return False
-        if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
             return False
         # elif self.context.seal:
         #     return True

--- a/imio/dms/mail/dmsmail.py
+++ b/imio/dms/mail/dmsmail.py
@@ -905,14 +905,14 @@ class ImioDmsOutgoingMailWfConditionsAdapter(object):
 
     def can_set_to_print(self):
         """Used in guard expression for to_print and back_to_print transitions."""
+        if self.context.esign:
+            return False
         brains = self.context.portal_catalog.unrestrictedSearchResults(
-            portal_type="dmsommainfile", path="/".join(self.context.getPhysicalPath()), b_size=1
+            portal_type="dmsommainfile", path="/".join(self.context.getPhysicalPath())
         )
         if not bool(brains):
             return False
         if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
-            return False
-        if self.context.esign:
             return False
         return True
 
@@ -921,7 +921,7 @@ class ImioDmsOutgoingMailWfConditionsAdapter(object):
     def can_be_signed(self):
         """Used in guard expression for to_be_signed transition."""
         brains = self.context.portal_catalog.unrestrictedSearchResults(
-            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath()), b_size=1
+            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath())
         )
         if not bool(brains):
             return False

--- a/imio/dms/mail/dmsmail.py
+++ b/imio/dms/mail/dmsmail.py
@@ -901,14 +901,27 @@ class ImioDmsOutgoingMailWfConditionsAdapter(object):
             return False
         return self.context.has_approvings()
 
-    security.declarePublic("can_be_handsigned")
+    security.declarePublic("can_set_to_print")
 
-    # TODO can be renamed as can_be_signed
-    def can_be_handsigned(self):
-        """Used in guard expression for to_be_signed transition."""
-        # TODO use to be printed criteria...
+    def can_set_to_print(self):
+        """Used in guard expression for to_print and back_to_print transitions."""
         brains = self.context.portal_catalog.unrestrictedSearchResults(
-            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath())
+            portal_type="dmsommainfile", path="/".join(self.context.getPhysicalPath()), b_size=1
+        )
+        if not bool(brains):
+            return False
+        if self.context.has_approvings() and not self.context.has_approvings(all_done=True):
+            return False
+        if self.context.esign:
+            return False
+        return True
+
+    security.declarePublic("can_be_signed")
+
+    def can_be_signed(self):
+        """Used in guard expression for to_be_signed transition."""
+        brains = self.context.portal_catalog.unrestrictedSearchResults(
+            portal_type=["dmsommainfile", "dmsappendixfile"], path="/".join(self.context.getPhysicalPath()), b_size=1
         )
         if not bool(brains):
             return False

--- a/imio/dms/mail/migrations/migrate_to_3_1_2.py
+++ b/imio/dms/mail/migrations/migrate_to_3_1_2.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.wfadaptations.api import get_applied_adaptations
 from imio.dms.mail.migrations.migrate_to_3_1 import Migrate_To_3_1
 from plone import api
 
@@ -16,7 +17,8 @@ class Migrate_To_3_1_2(Migrate_To_3_1):  # noqa
         if self.is_in_part("b"):  # upgrade other products
             self.upgradeAll(omit=[u"imio.dms.mail:default"])
 
-        if self.is_in_part("c"):  # migrate signer substitutes
+        if self.is_in_part("c"):
+            # Migrate signer substitutes
             logger.info("Migrating omail_signer_rules dates to omail_signer_substitutes")
             self.runProfileSteps("imio.dms.mail", steps=["plone.app.registry"])
             rk_rules = "imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_signer_rules"
@@ -61,8 +63,54 @@ class Migrate_To_3_1_2(Migrate_To_3_1):  # noqa
                 api.portal.set_registry_record(rk_rules, cleaned_rules)
                 api.portal.set_registry_record(rk_subs, substitutes)
                 logger.info("Created {} substitute stub(s) from signer rules".format(new_substitutes_count))
+
             # Changed permission after plone.restapi installation
             self.portal.manage_permission("plone.restapi: Use REST API", ("Member", ), acquire=0)
+
+            # WFAs
+            # can_be_handsigned was renamed can_be_signed
+            wf = api.portal.get().portal_workflow["outgoingmail_workflow"]
+            old_handsigned_guard = "python:object.wf_conditions().can_be_handsigned()"
+            new_signed_guard = "python:object.wf_conditions().can_be_signed()"
+            for tr_id in ("propose_to_be_signed", "back_to_be_signed"):
+                if tr_id not in wf.transitions:
+                    continue
+                tr = wf.transitions[tr_id]
+                if tr.guard.expr and tr.guard.expr.text == old_handsigned_guard:
+                    logger.info("Updating {} guard from can_be_handsigned to can_be_signed".format(tr_id))
+                    tr.setProperties(
+                        title=tr.title,
+                        new_state_id=tr.new_state_id,
+                        trigger_type=tr.trigger_type,
+                        script_name=tr.script_name,
+                        actbox_name=tr.actbox_name,
+                        actbox_url=tr.actbox_url,
+                        actbox_icon=tr.actbox_icon,
+                        actbox_category=tr.actbox_category,
+                        props={"guard_permissions": "Review portal content", "guard_expr": new_signed_guard},
+                    )
+            # Update guard expression on set_to_print/back_to_print wfa
+            applied_wfa_names = [dic["adaptation"] for dic in get_applied_adaptations()]
+            to_print_applied = "imio.dms.mail.wfadaptations.OMToPrintAdaptation" in applied_wfa_names
+            if to_print_applied:
+                new_guard = "python:object.wf_conditions().can_set_to_print()"
+                for tr_id in ("set_to_print", "back_to_print"):
+                    if tr_id not in wf.transitions:
+                        continue
+                    tr = wf.transitions[tr_id]
+                    if tr.guard.expr and tr.guard.expr.text == old_handsigned_guard:
+                        logger.info("Updating {} guard from can_be_handsigned to can_set_to_print".format(tr_id))
+                        tr.setProperties(
+                            title=tr.title,
+                            new_state_id=tr.new_state_id,
+                            trigger_type=tr.trigger_type,
+                            script_name=tr.script_name,
+                            actbox_name=tr.actbox_name,
+                            actbox_url=tr.actbox_url,
+                            actbox_icon=tr.actbox_icon,
+                            actbox_category=tr.actbox_category,
+                            props={"guard_permissions": "Review portal content", "guard_expr": new_guard},
+                        )
 
         if self.is_in_part("g"):  # final steps
             # finished = True  # can be eventually returned and set by batched method

--- a/imio/dms/mail/migrations/migrate_to_3_1_2.py
+++ b/imio/dms/mail/migrations/migrate_to_3_1_2.py
@@ -89,28 +89,6 @@ class Migrate_To_3_1_2(Migrate_To_3_1):  # noqa
                         actbox_category=tr.actbox_category,
                         props={"guard_permissions": "Review portal content", "guard_expr": new_signed_guard},
                     )
-            # Update guard expression on set_to_print/back_to_print wfa
-            applied_wfa_names = [dic["adaptation"] for dic in get_applied_adaptations()]
-            to_print_applied = "imio.dms.mail.wfadaptations.OMToPrintAdaptation" in applied_wfa_names
-            if to_print_applied:
-                new_guard = "python:object.wf_conditions().can_set_to_print()"
-                for tr_id in ("set_to_print", "back_to_print"):
-                    if tr_id not in wf.transitions:
-                        continue
-                    tr = wf.transitions[tr_id]
-                    if tr.guard.expr and tr.guard.expr.text == old_handsigned_guard:
-                        logger.info("Updating {} guard from can_be_handsigned to can_set_to_print".format(tr_id))
-                        tr.setProperties(
-                            title=tr.title,
-                            new_state_id=tr.new_state_id,
-                            trigger_type=tr.trigger_type,
-                            script_name=tr.script_name,
-                            actbox_name=tr.actbox_name,
-                            actbox_url=tr.actbox_url,
-                            actbox_icon=tr.actbox_icon,
-                            actbox_category=tr.actbox_category,
-                            props={"guard_permissions": "Review portal content", "guard_expr": new_guard},
-                        )
 
         if self.is_in_part("g"):  # final steps
             # finished = True  # can be eventually returned and set by batched method

--- a/imio/dms/mail/profiles/default/workflows/outgoingmail_workflow/definition.xml
+++ b/imio/dms/mail/profiles/default/workflows/outgoingmail_workflow/definition.xml
@@ -303,7 +303,7 @@
   <action url="" category="workflow" icon="%(portal_url)s/++resource++imio.dms.mail/om_back_to_be_signed.png" i18n:translate="">om_back_to_be_signed</action>
   <guard>
    <guard-permission>Review portal content</guard-permission>
-   <guard-expression>python:object.wf_conditions().can_be_handsigned()</guard-expression>
+   <guard-expression>python:object.wf_conditions().can_be_signed()</guard-expression>
   </guard>
  </transition>
  <transition transition_id="back_to_creation" title="om_back_to_creation" new_state="created" trigger="USER" before_script="" after_script="" i18n:attributes="title">
@@ -344,7 +344,7 @@
   <action url="" category="workflow" icon="%(portal_url)s/++resource++imio.dms.mail/om_propose_to_be_signed.png" i18n:translate="">om_propose_to_be_signed</action>
   <guard>
    <guard-permission>Review portal content</guard-permission>
-   <guard-expression>python:object.wf_conditions().can_be_handsigned()</guard-expression>
+   <guard-expression>python:object.wf_conditions().can_be_signed()</guard-expression>
   </guard>
  </transition>
  <transition transition_id="set_scanned" title="om_set_scanned" new_state="scanned" trigger="USER" before_script="" after_script="" i18n:attributes="title">

--- a/imio/dms/mail/steps.py
+++ b/imio/dms/mail/steps.py
@@ -146,8 +146,6 @@ def activate_esigning(context):
         pos = om_fns.index("ISigningBehavior.signers")
         omf.insert(pos + 1,
                    {"field_name": "ISigningBehavior.esign", "read_tal_condition": u"", "write_tal_condition": u""})
-        # omf.insert(pos + 2,
-        #            {"field_name": "ISigningBehavior.seal", "read_tal_condition": u"", "write_tal_condition": u""})
         api.portal.set_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_fields",
                                        omf)
         log.append("Added esign to omail_fields registry record")

--- a/imio/dms/mail/steps.py
+++ b/imio/dms/mail/steps.py
@@ -138,13 +138,19 @@ def activate_esigning(context):
         pos = om_fns.index("internal_reference_no")
         omf.insert(pos + 1,
                    {"field_name": "ISigningBehavior.signers", "read_tal_condition": u"", "write_tal_condition": u""})
-        # omf.insert(pos + 2,
-        #            {"field_name": "ISigningBehavior.seal", "read_tal_condition": u"", "write_tal_condition": u""})
-        omf.insert(pos + 2,
-                   {"field_name": "ISigningBehavior.esign", "read_tal_condition": u"", "write_tal_condition": u""})
+        om_fns = [dic["field_name"] for dic in omf]
         api.portal.set_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_fields",
                                        omf)
-        log.append("Updated omail_fields registry record")
+        log.append("Added signers to omail_fields registry record")
+    if "ISigningBehavior.esign" not in om_fns:
+        pos = om_fns.index("ISigningBehavior.signers")
+        omf.insert(pos + 1,
+                   {"field_name": "ISigningBehavior.esign", "read_tal_condition": u"", "write_tal_condition": u""})
+        # omf.insert(pos + 2,
+        #            {"field_name": "ISigningBehavior.seal", "read_tal_condition": u"", "write_tal_condition": u""})
+        api.portal.set_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_fields",
+                                       omf)
+        log.append("Added esign to omail_fields registry record")
 
     site.portal_setup.runImportStepFromProfile(
         "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False

--- a/imio/dms/mail/tests/test_dmsmail.py
+++ b/imio/dms/mail/tests/test_dmsmail.py
@@ -35,6 +35,8 @@ from zope.interface import Invalid
 from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent import modified
 
+from mock import patch
+
 import unittest
 
 
@@ -565,19 +567,37 @@ class TestDmsmail(unittest.TestCase, ImioTestHelpers):
             u'"Dexter Morgan" <contak@electrabel.eb>, "Jean Courant" <jean.courant@electrabel.eb>',
         )
 
-    def test_ImioDmsOutgoingMailWfConditionsAdapter_can_be_handsigned(self):
+    def test_ImioDmsOutgoingMailWfConditionsAdapter_can_set_to_print(self):
         omail = sub_create(self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id")
         self.assertEqual(api.content.get_state(omail), "created")
         adapted = omail.wf_conditions()
-        self.assertFalse(adapted.can_be_handsigned())
+        self.assertFalse(adapted.can_set_to_print())
         createContentInContainer(omail, "task")
-        self.assertFalse(adapted.can_be_handsigned())
+        self.assertFalse(adapted.can_set_to_print())
         createContentInContainer(omail, "dmsappendixfile")
-        self.assertTrue(adapted.can_be_handsigned())
+        self.assertFalse(adapted.can_set_to_print())
+        createContentInContainer(omail, "dmsommainfile")
+        self.assertTrue(adapted.can_set_to_print())
+        # When approvings exist but are not done, cannot set to print
+        with patch.object(omail, "has_approvings", side_effect=lambda all_done=False: not all_done):
+            self.assertFalse(adapted.can_set_to_print())
+        # When all approvings are done, can set to print
+        with patch.object(omail, "has_approvings", return_value=True):
+            self.assertTrue(adapted.can_set_to_print())
+
+    def test_ImioDmsOutgoingMailWfConditionsAdapter_can_be_signed(self):
+        omail = sub_create(self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id")
+        self.assertEqual(api.content.get_state(omail), "created")
+        adapted = omail.wf_conditions()
+        self.assertFalse(adapted.can_be_signed())
+        createContentInContainer(omail, "task")
+        self.assertFalse(adapted.can_be_signed())
+        createContentInContainer(omail, "dmsappendixfile")
+        self.assertTrue(adapted.can_be_signed())
         filename = u"Réponse salle.odt"
         with open("%s/batchimport/toprocess/outgoing-mail/%s" % (PRODUCT_DIR, filename), "rb") as fo:
             createContentInContainer(omail, "dmsommainfile", file=NamedBlobFile(fo.read(), filename=filename))
-        self.assertTrue(adapted.can_be_handsigned())
+        self.assertTrue(adapted.can_be_signed())
 
     def test_ImioDmsOutgoingMailWfConditionsAdapter_can_be_sent(self):
         omail = sub_create(self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id", title=u"test")

--- a/imio/dms/mail/tests/test_wfadaptations.py
+++ b/imio/dms/mail/tests/test_wfadaptations.py
@@ -3,8 +3,10 @@
 
 from collective.contact.plonegroup.config import get_registry_functions
 from collective.contact.plonegroup.config import get_registry_organizations
+from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import datetime
 from imio.dms.mail import PRODUCT_DIR
+from imio.dms.mail.interfaces import IOMApproval
 from imio.dms.mail.testing import change_user
 from imio.dms.mail.testing import DMSMAIL_INTEGRATION_TESTING
 from imio.dms.mail.testing import reset_dms_config
@@ -13,7 +15,6 @@ from imio.dms.mail.utils import group_has_user
 from imio.dms.mail.utils import sub_create
 from imio.dms.mail.vocabularies import encodeur_active_orgs
 from imio.dms.mail.wfadaptations import IMPreManagerValidation
-from imio.dms.mail.wfadaptations import OMToPrintAdaptation
 from imio.helpers.content import get_object
 from plone import api
 from plone.app.testing import setRoles
@@ -31,7 +32,7 @@ import unittest
 import zope.event
 
 
-class TestOMToPrintAdaptation(unittest.TestCase):
+class BaseTestWFAdaptations(unittest.TestCase):
 
     layer = DMSMAIL_INTEGRATION_TESTING
 
@@ -40,22 +41,197 @@ class TestOMToPrintAdaptation(unittest.TestCase):
         change_user(self.portal)
         self.pw = self.portal.portal_workflow
         self.omw = self.pw["outgoingmail_workflow"]
+        self.pgof = self.portal["contacts"]["plonegroup-organization"]
         api.group.create("abc_group_encoder", "ABC group encoder")
-        self.omail = sub_create(
-            self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id", title=u"Test"
-        )
 
     def tearDown(self):
         # the modified dmsconfig is kept globally
         reset_dms_config()
 
+    def _get_transition_ids(self, obj):
+        return {tr["id"] for tr in self.pw.getTransitionsFor(obj)}
+
+    def common_toprint_toapprove(self):
+        # --- handsigned document, without approval ---
+        pf = self.portal["contacts"]["personnel-folder"]
+        bourgmestre_hp = pf["bourgmestre"]["bourgmestre"]
+        omail1 = sub_create(
+            self.portal["outgoing-mail"],
+            "dmsoutgoingmail",
+            datetime.now(),
+            "id-1",
+            title="My title",
+            description="Description",
+            send_modes=["post"],
+            treating_groups=self.pgof["direction-generale"].UID(),
+            mail_type="courrier",
+            signers=[{"signer": bourgmestre_hp.UID(), "approvings": [u"_empty_"], "number": 1, "editor": False}],
+        )
+        self.assertSetEqual(self._get_transition_ids(omail1), {"mark_as_sent"})
+
+        filepath = "%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR
+        with open(filepath, "rb") as fo:
+            file_object = NamedBlobFile(fo.read(), filename=u"example.odt")
+            createContentInContainer(omail1, "dmsommainfile", id="1", title="Example", file=file_object)
+        self.assertSetEqual(self._get_transition_ids(omail1), {"set_to_print", "propose_to_be_signed", "mark_as_sent"})
+
+        self.pw.doActionFor(omail1, "set_to_print")
+        self.assertEqual(api.content.get_state(omail1), "to_print")
+        self.assertSetEqual(self._get_transition_ids(omail1), {"back_to_creation", "propose_to_be_signed"})
+
+        self.pw.doActionFor(omail1, "propose_to_be_signed")
+        self.assertEqual(api.content.get_state(omail1), "to_be_signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail1), {"back_to_creation", "back_to_print", "mark_as_signed", "mark_as_sent"}
+        )
+
+        self.pw.doActionFor(omail1, "mark_as_signed")
+        self.assertEqual(api.content.get_state(omail1), "signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail1),
+            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"},
+        )
+
+        self.pw.doActionFor(omail1, "mark_as_sent")
+        self.assertEqual(api.content.get_state(omail1), "sent")
+        self.assertSetEqual(
+            self._get_transition_ids(omail1),
+            {"back_to_creation", "back_to_print", "back_to_be_signed", "back_to_signed", "back_to_scanned"},
+        )
+
+        # --- handsigned document, with approval ---
+        omail2 = sub_create(
+            self.portal["outgoing-mail"],
+            "dmsoutgoingmail",
+            datetime.now(),
+            "id-2",
+            title="My title",
+            description="Description",
+            send_modes=["post"],
+            treating_groups=self.pgof["direction-generale"].UID(),
+            mail_type="courrier",
+            signers=[{"signer": bourgmestre_hp.UID(), "approvings": [u"_themself_"], "number": 1, "editor": False}],
+        )
+        self.assertSetEqual(self._get_transition_ids(omail2), {"mark_as_sent"})
+
+        filepath = "%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR
+        ct = self.portal["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"]
+        with open(filepath, "rb") as fo:
+            file_object = NamedBlobFile(fo.read(), filename=u"example.odt")
+            file2 = createContentInContainer(
+                omail2,
+                "dmsommainfile",
+                id="2",
+                title="Example",
+                file=file_object,
+                content_category=calculate_category_id(ct),
+            )
+        self.assertSetEqual(self._get_transition_ids(omail2), {"propose_to_approve", "mark_as_sent"})
+
+        self.pw.doActionFor(omail2, "propose_to_approve")
+        self.assertEqual(api.content.get_state(omail2), "to_approve")
+        self.assertSetEqual(self._get_transition_ids(omail2), {"back_to_creation"})
+
+        IOMApproval(omail2).approve_file(file2, "bourgmestre", transition=True)
+        self.assertEqual(api.content.get_state(omail2), "to_print")
+        self.assertSetEqual(
+            self._get_transition_ids(omail2), {"back_to_creation", "back_to_approve", "propose_to_be_signed"}
+        )
+
+        self.pw.doActionFor(omail2, "propose_to_be_signed")
+        self.assertEqual(api.content.get_state(omail2), "to_be_signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail2),
+            {"back_to_creation", "back_to_approve", "back_to_print", "mark_as_signed", "mark_as_sent"},
+        )
+
+        self.pw.doActionFor(omail2, "mark_as_signed")
+        self.assertEqual(api.content.get_state(omail2), "signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail2),
+            {"back_to_creation", "back_to_be_signed", "back_to_scanned", "mark_as_sent"},
+        )
+
+        self.pw.doActionFor(omail2, "mark_as_sent")
+        self.assertEqual(api.content.get_state(omail2), "sent")
+        self.assertSetEqual(
+            self._get_transition_ids(omail2),
+            {"back_to_creation", "back_to_print", "back_to_be_signed", "back_to_signed", "back_to_scanned"},
+        )
+
+        # --- esigned document, with approval ---
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-activate-esigning", run_dependencies=False
+        )
+        omail3 = sub_create(
+            self.portal["outgoing-mail"],
+            "dmsoutgoingmail",
+            datetime.now(),
+            "id-3",
+            title="My title",
+            description="Description",
+            send_modes=["post"],
+            treating_groups=self.pgof["direction-generale"].UID(),
+            mail_type="courrier",
+            signers=[{"signer": bourgmestre_hp.UID(), "approvings": [u"_themself_"], "number": 1, "editor": False}],
+            esign=True,
+        )
+        self.assertSetEqual(self._get_transition_ids(omail3), {"mark_as_sent"})
+
+        filepath = "%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR
+        ct = self.portal["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"]
+        with open(filepath, "rb") as fo:
+            file_object = NamedBlobFile(fo.read(), filename=u"example.odt")
+            file3 = createContentInContainer(
+                omail3,
+                "dmsommainfile",
+                id="3",
+                title="Example",
+                file=file_object,
+                content_category=calculate_category_id(ct),
+            )
+        self.assertSetEqual(self._get_transition_ids(omail3), {"propose_to_approve", "mark_as_sent"})
+
+        self.pw.doActionFor(omail3, "propose_to_approve")
+        self.assertEqual(api.content.get_state(omail3), "to_approve")
+        self.assertSetEqual(self._get_transition_ids(omail3), {"back_to_creation"})
+
+        IOMApproval(omail3).approve_file(file3, "bourgmestre", transition=True)
+        self.assertEqual(api.content.get_state(omail3), "to_be_signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail3), {"back_to_creation", "back_to_approve", "mark_as_signed", "mark_as_sent"}
+        )
+
+        self.pw.doActionFor(omail3, "mark_as_signed")
+        self.assertEqual(api.content.get_state(omail3), "signed")
+        self.assertSetEqual(
+            self._get_transition_ids(omail3),
+            {"back_to_creation", "back_to_be_signed", "back_to_scanned", "mark_as_sent"},
+        )
+
+        self.pw.doActionFor(omail3, "mark_as_sent")
+        self.assertEqual(api.content.get_state(omail3), "sent")
+        self.assertSetEqual(
+            self._get_transition_ids(omail3),
+            {"back_to_creation", "back_to_be_signed", "back_to_signed", "back_to_scanned"},
+        )
+
+
+class TestOMToPrintAdaptation(BaseTestWFAdaptations):
+
+    def setUp(self):
+        super(TestOMToPrintAdaptation, self).setUp()
+        self.omail = sub_create(
+            self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id", title=u"Test"
+        )
+
     def test_OMToPrintAdaptation(self):
         """Test wf adaptation modifications"""
-        tpa = OMToPrintAdaptation()
-        tpa.patch_workflow("outgoingmail_workflow")
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
+        )
         # check workflow
-        self.assertSetEqual(set(self.omw.states),
-                            {"created", "scanned", "to_print", "to_be_signed", "signed", "sent"})
+        self.assertSetEqual(set(self.omw.states), {"created", "scanned", "to_print", "to_be_signed", "signed", "sent"})
         self.assertSetEqual(
             set(self.omw.transitions),
             {
@@ -80,15 +256,15 @@ class TestOMToPrintAdaptation(unittest.TestCase):
         self.assertSetEqual(set(self.omw.states["to_print"].transitions), {"back_to_creation", "propose_to_be_signed"})
         self.assertSetEqual(
             set(self.omw.states["to_be_signed"].transitions),
-            {"back_to_creation", "back_to_print", "mark_as_sent", "mark_as_signed"}
+            {"back_to_creation", "back_to_print", "mark_as_sent", "mark_as_signed"},
         )
         self.assertSetEqual(
             set(self.omw.states["signed"].transitions),
-            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"}
+            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"},
         )
         self.assertSetEqual(
             set(self.omw.states["sent"].transitions),
-            {"back_to_print", "back_to_be_signed", "back_to_signed", "back_to_scanned", "back_to_creation"}
+            {"back_to_print", "back_to_be_signed", "back_to_signed", "back_to_scanned", "back_to_creation"},
         )
         # various
         fti = getUtility(IDexterityFTI, name="dmsoutgoingmail")
@@ -104,11 +280,15 @@ class TestOMToPrintAdaptation(unittest.TestCase):
         factory = getUtility(IVocabularyFactory, u"imio.dms.mail.OMReviewStatesVocabulary")
         self.assertEqual(len(factory(self.portal)), 6)
 
+        # Add ToApprove adaptation
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self.common_toprint_toapprove()
+
     def common_tests(self):
         # check workflow
-        self.assertSetEqual(
-            set(self.omw.states), {"created", "scanned", "to_print", "to_be_signed", "signed", "sent"}
-        )
+        self.assertSetEqual(set(self.omw.states), {"created", "scanned", "to_print", "to_be_signed", "signed", "sent"})
         self.assertSetEqual(
             set(self.omw.transitions),
             {
@@ -140,7 +320,7 @@ class TestOMToPrintAdaptation(unittest.TestCase):
         )
         self.assertSetEqual(
             set(self.omw.states["signed"].transitions),
-            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"}
+            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"},
         )
         self.assertSetEqual(
             set(self.omw.states["sent"].transitions),
@@ -159,21 +339,175 @@ class TestOMToPrintAdaptation(unittest.TestCase):
         self.assertIsNone(self.omail.treating_groups)
 
     def test_OMToPrintAdaptationBeforeNp1(self):
-        """Test wf adaptation modifications"""
-        tpa = OMToPrintAdaptation()
-        tpa.patch_workflow("outgoingmail_workflow")
+        """Test wf adaptation is idempotent when applied twice"""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
+        )
         self.portal.portal_setup.runImportStepFromProfile(
             "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
         )
         self.common_tests()
 
     def test_OMToPrintAdaptationAfterNp1(self):
-        """Test wf adaptation modifications"""
+        """Test wf adaptation is idempotent when applied twice"""
         self.portal.portal_setup.runImportStepFromProfile(
             "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
         )
-        tpa = OMToPrintAdaptation()
-        tpa.patch_workflow("outgoingmail_workflow")
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
+        )
+        self.common_tests()
+
+
+class TestOMToApproveAdaptation(BaseTestWFAdaptations):
+
+    def setUp(self):
+        super(TestOMToApproveAdaptation, self).setUp()
+        self.omail = sub_create(
+            self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "test-id", title=u"Test"
+        )
+
+    def test_OMToApproveAdaptation(self):
+        """Test wf adaptation modifications"""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        # check workflow
+        self.assertSetEqual(
+            set(self.omw.states), {"created", "scanned", "to_approve", "to_be_signed", "signed", "sent"}
+        )
+        self.assertSetEqual(
+            set(self.omw.transitions),
+            {
+                "back_to_creation",
+                "back_to_agent",
+                "back_to_scanned",
+                "back_to_approve",
+                "back_to_be_signed",
+                "back_to_signed",
+                "set_scanned",
+                "propose_to_approve",
+                "propose_to_be_signed",
+                "mark_as_sent",
+                "mark_as_signed",
+            },
+        )
+        self.assertSetEqual(
+            set(self.omw.states["created"].transitions),
+            {"set_scanned", "propose_to_be_signed", "mark_as_sent", "propose_to_approve"},
+        )
+        self.assertSetEqual(set(self.omw.states["scanned"].transitions), {"back_to_agent", "mark_as_sent"})
+        self.assertSetEqual(
+            set(self.omw.states["to_approve"].transitions), {"propose_to_be_signed", "back_to_creation"}
+        )
+        self.assertSetEqual(
+            set(self.omw.states["to_be_signed"].transitions),
+            {"back_to_creation", "back_to_approve", "mark_as_sent", "mark_as_signed"},
+        )
+        self.assertSetEqual(
+            set(self.omw.states["signed"].transitions),
+            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"},
+        )
+        self.assertSetEqual(
+            set(self.omw.states["sent"].transitions),
+            {"back_to_creation", "back_to_be_signed", "back_to_signed", "back_to_scanned"},
+        )
+        # various
+        fti = getUtility(IDexterityFTI, name="dmsoutgoingmail")
+        lr = getattr(fti, "localroles")
+        self.assertIn("to_approve", lr["static_config"])
+        self.assertIn("to_approve", lr["treating_groups"])
+        self.assertIn("to_approve", lr["recipient_groups"])
+        folder = self.portal["outgoing-mail"]["mail-searches"]
+        self.assertIn("searchfor_to_approve", folder)
+        self.assertIn("to_approve", folder)
+        self.assertIn("in_esign_sessions", folder)
+        self.assertIn(
+            "to_approve",
+            [dic["v"] for dic in folder["om_treating"].query if dic["i"] == "review_state"][0],
+        )
+        self.assertEqual(folder.getObjectPosition("searchfor_to_be_signed"), 13)
+        self.assertEqual(folder.getObjectPosition("searchfor_to_approve"), 12)
+        factory = getUtility(IVocabularyFactory, u"imio.dms.mail.OMReviewStatesVocabulary")
+        self.assertEqual(len(factory(self.portal)), 6)
+
+        # Add ToPrint adaptation
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_print_wfadaptation", run_dependencies=False
+        )
+        self.common_toprint_toapprove()
+
+    def common_tests(self):
+        # check workflow
+        self.assertSetEqual(
+            set(self.omw.states), {"created", "scanned", "to_approve", "to_be_signed", "signed", "sent"}
+        )
+        self.assertSetEqual(
+            set(self.omw.transitions),
+            {
+                "back_to_creation",
+                "back_to_agent",
+                "back_to_scanned",
+                "back_to_approve",
+                "back_to_be_signed",
+                "back_to_signed",
+                "set_scanned",
+                "propose_to_approve",
+                "propose_to_be_signed",
+                "mark_as_sent",
+                "mark_as_signed",
+            },
+        )
+        self.assertSetEqual(
+            set(self.omw.states["created"].transitions),
+            {"set_scanned", "propose_to_be_signed", "mark_as_sent", "propose_to_approve"},
+        )
+        self.assertSetEqual(set(self.omw.states["scanned"].transitions), {"back_to_agent", "mark_as_sent"})
+        self.assertSetEqual(
+            set(self.omw.states["to_approve"].transitions), {"propose_to_be_signed", "back_to_creation"}
+        )
+        self.assertSetEqual(
+            set(self.omw.states["to_be_signed"].transitions),
+            {"back_to_creation", "back_to_approve", "mark_as_sent", "mark_as_signed"},
+        )
+        self.assertSetEqual(
+            set(self.omw.states["signed"].transitions),
+            {"back_to_be_signed", "back_to_scanned", "back_to_creation", "mark_as_sent"},
+        )
+        self.assertSetEqual(
+            set(self.omw.states["sent"].transitions),
+            {"back_to_creation", "back_to_be_signed", "back_to_signed", "back_to_scanned"},
+        )
+        # check collection positions
+        folder = self.portal["outgoing-mail"]["mail-searches"]
+        self.assertEqual(folder.getObjectPosition("searchfor_to_be_signed"), 13)
+        self.assertEqual(folder.getObjectPosition("searchfor_to_approve"), 12)
+        res = [dic["v"] for dic in folder["om_treating"].query if dic["i"] == "review_state"][0]
+        self.assertIn("to_approve", res)
+        # check dms config
+        change_user(self.portal, "test-user")
+        setRoles(self.portal, TEST_USER_ID, ["Reviewer", "Manager"])
+        # no treating_groups: NOK
+        self.assertIsNone(self.omail.treating_groups)
+
+    def test_OMToApproveAdaptationBeforeNp1(self):
+        """Test wf adaptation is idempotent when applied twice"""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self.common_tests()
+
+    def test_OMToApproveAdaptationAfterNp1(self):
+        """Test wf adaptation is idempotent when applied twice"""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
         self.common_tests()
 
 

--- a/imio/dms/mail/utils.py
+++ b/imio/dms/mail/utils.py
@@ -1524,6 +1524,19 @@ def do_next_transition(mail, ptype, treating_group="", state=None, config=None):
         api.content.transition(mail, config[state][treating_group][0])
 
 
+def get_post_approval_transition(context):
+    """Return the transition to trigger when all approvals are done.
+
+    When OMToPrintAdaptation is applied (handsigned flow), the mail goes to
+    to_print after approval instead of directly to to_be_signed.
+    """
+    pw = api.portal.get().portal_workflow
+    trs = [tr['id'] for tr in pw.getTransitionsFor(context)]
+    if "set_to_print" in trs:
+        return "set_to_print"
+    return "propose_to_be_signed"
+
+
 def is_valid_identifier(identifier):
     idnormalizer = getUtility(IIDNormalizer)
     return idnormalizer.normalize(identifier) == identifier

--- a/imio/dms/mail/wfadaptations.py
+++ b/imio/dms/mail/wfadaptations.py
@@ -1040,6 +1040,14 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
                         OrderedDict([('_n_plus_1', {'org': 'treating_groups', 'st': ['proposed_to_n_plus_1']})]))
         set_dms_config(["review_states", "dmsoutgoingmail"],
                         OrderedDict([('proposed_to_n_plus_1', {'org': 'treating_groups', 'group': '_n_plus_1'})]))
+
+        default settings for case 3
+        set_dms_config(["wf_from_to", "dmsoutgoingmail", "n_plus", "from"], [("created", "back_to_creation")])
+        set_dms_config(["wf_from_to", "dmsoutgoingmail", "n_plus", "to"],
+                       [('sent', 'mark_as_sent'), ('to_be_signed', 'propose_to_be_signed'),
+                       ('to_print', 'set_to_print')])
+        set_dms_config(["review_levels", "dmsoutgoingmail"], OrderedDict())
+        set_dms_config(["review_states", "dmsoutgoingmail"], OrderedDict())
         """
         # modify wf_from_to
         nplus_to = get_dms_config(["wf_from_to", "dmsoutgoingmail", "n_plus", "to"])

--- a/imio/dms/mail/wfadaptations.py
+++ b/imio/dms/mail/wfadaptations.py
@@ -1009,9 +1009,9 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
         possible cases:
         1) basic: created -> to_approve -> to_be_signed
         2) n+1 applied: created -> proposed_to_n_plus -> validated -> to_approve -> to_be_signed
-        3) to_print applied: created -> to_print -> to_approve -> to_be_signed
+        3) to_print applied: created -> to_approve -> to_print -> to_be_signed
         """
-        # TODO : Check cases 2 and 3
+        # TODO : Check case 2
         transitions = ["propose_to_be_signed", "back_to_creation"]
         # what is already applied ?
         already_applied = ""
@@ -1022,7 +1022,7 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
             transitions.append("back_to_validated")
         if u"imio.dms.mail.wfadaptations.OMToPrintAdaptation" in applied_wfa:
             already_applied = "to_print"
-            transitions.append("back_to_print")
+            transitions.append("set_to_print")
         """
         default settings for case 1
         set_dms_config(["wf_from_to", "dmsoutgoingmail", "n_plus", "from"], [("created", "back_to_creation")])
@@ -1105,9 +1105,11 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
         transitions.append(to_tr_id)
         wf.states["created"].transitions = tuple(transitions)
         if already_applied == "to_print":
-            transitions = list(wf.states["to_print"].transitions)
-            transitions.append(to_tr_id)
-            wf.states["to_print"].transitions = tuple(transitions)
+            # Add "set_to_print" from to_approve
+            transitions = list(state.transitions)
+            if "set_to_print" not in transitions:
+                transitions.append("set_to_print")
+            state.transitions = tuple(transitions)
         if already_applied == "n_plus":
             for st in ("proposed_to_n_plus_1", "validated"):
                 transitions = list(wf.states[st].transitions)
@@ -1115,16 +1117,34 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
                 wf.states[st].transitions = tuple(transitions)
 
         # add new back_to transition on next states
-        for next_state_id in to_states:
-            if next_state_id not in wf.states:  # can be when wfadaptations are re-applied during migration
-                continue
-            if new_state_id == next_state_id or next_state_id == "validated":
-                continue
-            next_state = wf.states[next_state_id]
-            transitions = list(next_state.transitions)
-            if back_tr_id not in transitions:
-                transitions.append(back_tr_id)
-            next_state.transitions = tuple(transitions)
+        if already_applied == "to_print":
+            # Add "back_to_approve" from to_print
+            to_print_state = wf.states["to_print"]
+            tp_transitions = list(to_print_state.transitions)
+            if back_tr_id not in tp_transitions:
+                tp_transitions.append(back_tr_id)
+            to_print_state.transitions = tuple(tp_transitions)
+            # Add "back_to_approve" from to_be_signed
+            to_be_signed_state = wf.states["to_be_signed"]
+            tbs_transitions = list(to_be_signed_state.transitions)
+            if back_tr_id not in tbs_transitions:
+                # before "back_to_print" (earlier state in flow)
+                if "back_to_print" in tbs_transitions:
+                    tbs_transitions.insert(tbs_transitions.index("back_to_print"), back_tr_id)
+                else:
+                    tbs_transitions.append(back_tr_id)
+            to_be_signed_state.transitions = tuple(tbs_transitions)
+        else:
+            for next_state_id in to_states:
+                if next_state_id not in wf.states:  # can be when wfadaptations are re-applied during migration
+                    continue
+                if new_state_id == next_state_id or next_state_id == "validated" or next_state_id == "sent":
+                    continue
+                next_state = wf.states[next_state_id]
+                transitions = list(next_state.transitions)
+                if back_tr_id not in transitions:
+                    transitions.append(back_tr_id)
+                next_state.transitions = tuple(transitions)
 
         # ajouter config local roles
         lr, fti = fti_configuration(portal_type="dmsoutgoingmail")
@@ -1309,6 +1329,14 @@ class OMToPrintAdaptation(WorkflowAdaptationBase):
             return False, "N+1 already in workflow. Validated state can be used as to_print"
             # transitions.append("back_to_n_plus_1")
             # has_n_plus_1 = True
+        if u"imio.dms.mail.wfadaptations.OMToApproveAdaptation" in applied_wfa:
+            transitions.append("back_to_approve")
+            # Add "set_to_print" from to_approve
+            ta_state = wf.states["to_approve"]
+            ta_transitions = list(ta_state.transitions)
+            if to_tr_id not in ta_transitions:
+                ta_transitions.append(to_tr_id)
+            ta_state.transitions = tuple(ta_transitions)
 
         # modify wf_from_to
         nplus_to = get_dms_config(["wf_from_to", "dmsoutgoingmail", "n_plus", "to"])
@@ -1350,7 +1378,7 @@ class OMToPrintAdaptation(WorkflowAdaptationBase):
             actbox_category="workflow",
             props={
                 "guard_permissions": "Review portal content",
-                "guard_expr": "python:object.wf_conditions().can_be_handsigned()",
+                "guard_expr": "python:object.wf_conditions().can_set_to_print()",
             },
         )
         wf.transitions.addTransition(back_tr_id)
@@ -1365,7 +1393,7 @@ class OMToPrintAdaptation(WorkflowAdaptationBase):
             actbox_category="workflow",
             props={
                 "guard_permissions": "Review portal content",
-                "guard_expr": "python:object.wf_conditions().can_be_handsigned()",
+                "guard_expr": "python:object.wf_conditions().can_set_to_print()",
             },
         )
 
@@ -1474,6 +1502,8 @@ class OMToPrintAdaptation(WorkflowAdaptationBase):
             api.portal.set_registry_record(
                 "imio.actionspanel.browser.registry.IImioActionsPanelConfig.transitions", lst
             )
+        invalidate_cachekey_volatile_for("imio.dms.mail.utils.list_wf_states.dmsoutgoingmail")
+
         # update remark states
         lst = (
             api.portal.get_registry_record(
@@ -1484,8 +1514,6 @@ class OMToPrintAdaptation(WorkflowAdaptationBase):
         if new_state_id not in lst:
             lst.insert(0, new_state_id)
             api.portal.set_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_remark_states", lst)
-
-        invalidate_cachekey_volatile_for("imio.dms.mail.utils.list_wf_states.dmsoutgoingmail")
 
         return True, ""
 


### PR DESCRIPTION
J'ai branché cette PR sur la branche PARAF-402 parce que la nouvelle migration a été écrite là-bas...

Voir commentaire sur https://my.support.imio.be/browse/PARAF-403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Signing/printing guards now block actions when approvals are incomplete or e-sign is enabled; approval reindexing and status updates are more reliable.

* **Refactor**
  * Approval now auto-resolves the correct post-approval transition based on workflow availability.
  * Workflow transition wiring and guard targets updated for consistent approve/print/sign flows.

* **Migrations**
  * Workflow guards updated during migration to align with renamed guard checks.

* **Tests**
  * Expanded coverage for guard behavior, approval-driven transitions and end-to-end workflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->