### PR TITLE
Moved im and om content categories to setuphandlers

### DIFF
--- a/imio/dms/mail/examples.py
+++ b/imio/dms/mail/examples.py
@@ -132,93 +132,13 @@ def add_test_annexes_types(context):
             predefined_title=title,
         )
 
-    # Category Group for dms main files in incoming mails
-    incoming_dms_files_category_group = ccc["incoming_dms_files"]
-    oid, title, img = "incoming-dms-file", _("Incoming DMS File"), u"file-alt-regular.png"
-    if oid not in incoming_dms_files_category_group:
-        icon_path = os.path.join(context._profile_path, "images", img)
-        with open(icon_path, "rb") as fl:
-            icon = NamedBlobImage(fl.read(), filename=img)
-        api.content.create(
-            type="ContentCategory",
-            title=title,
-            description=u"",
-            container=incoming_dms_files_category_group,
-            icon=icon,
-            id=oid,
-            predefined_title=title,
-        )
-
-    # Category Group for appendix files in incoming mails
-    incoming_appendix_files_category_group = ccc["incoming_appendix_files"]
-    oid, title, img = "incoming-appendix-file", _("Incoming Appendix File"), u"attach.png"
-    if oid not in incoming_appendix_files_category_group:
-        icon_path = os.path.join(context._profile_path, "images", img)
-        with open(icon_path, "rb") as fl:
-            icon = NamedBlobImage(fl.read(), filename=img)
-        api.content.create(
-            type="ContentCategory",
-            title=title,
-            description=u"",
-            container=incoming_appendix_files_category_group,
-            icon=icon,
-            id=oid,
-            predefined_title=title,
-        )
-
-    # Category Group for dms main files in outgoing mails
-    outgoing_dms_files_category_group = ccc["outgoing_dms_files"]
-    icats = (
-        ("outgoing-dms-file", _("Outgoing DMS File"), u"file-alt-regular.png", True, True),
-        ("outgoing-scanned-dms-file", _("Outgoing Scanned DMS File"), u"file-alt-regular.png", True, False),
-    )
-    for oid, title, img, to_sign, to_approve in icats:
-        if oid in outgoing_dms_files_category_group:
-            continue
-        icon_path = os.path.join(context._profile_path, "images", img)
-        with open(icon_path, "rb") as fl:
-            icon = NamedBlobImage(fl.read(), filename=img)
-        api.content.create(
-            type="ContentCategory",
-            title=title,
-            description=u"",
-            container=outgoing_dms_files_category_group,
-            icon=icon,
-            id=oid,
-            predefined_title=title,
-            to_sign=to_sign,
-            to_approve=to_approve,
-        )
+    # Assign default content category to templates
     templates = site.portal_catalog.unrestrictedSearchResults(portal_type=["ConfigurablePODTemplate"])
     category_id = calculate_category_id(site["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"])
     for template in templates:
         obj = template.getObject()
         if not obj.default_content_category:
             obj.default_content_category = category_id
-
-    # Category Group for appendix files in outgoing mails
-    outgoing_appendix_files_category_group = ccc["outgoing_appendix_files"]
-    icats = (
-        ("outgoing-appendix-file", _("Outgoing Appendix File"), u"attach.png", False, False),
-        ("outgoing-signable-appendix-file", _("Outgoing Signable Appendix File"), u"attach-esign.png", True, True),
-    )
-    for oid, title, img, to_sign, to_approve in icats:
-        if oid in outgoing_appendix_files_category_group:
-            continue
-        icon_path = os.path.join(context._profile_path, "images", img)
-        with open(icon_path, "rb") as fl:
-            icon = NamedBlobImage(fl.read(), filename=img)
-        api.content.create(
-            type="ContentCategory",
-            title=title,
-            description=u"",
-            container=outgoing_appendix_files_category_group,
-            icon=icon,
-            id=oid,
-            predefined_title=title,
-            to_sign=to_sign,
-            to_approve=to_approve,
-        )
 
 
 def add_test_contact_lists(context):

--- a/imio/dms/mail/examples.py
+++ b/imio/dms/mail/examples.py
@@ -132,14 +132,6 @@ def add_test_annexes_types(context):
             predefined_title=title,
         )
 
-    # Assign default content category to templates
-    templates = site.portal_catalog.unrestrictedSearchResults(portal_type=["ConfigurablePODTemplate"])
-    category_id = calculate_category_id(site["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"])
-    for template in templates:
-        obj = template.getObject()
-        if not obj.default_content_category:
-            obj.default_content_category = category_id
-
 
 def add_test_contact_lists(context):
     """

--- a/imio/dms/mail/setuphandlers.py
+++ b/imio/dms/mail/setuphandlers.py
@@ -19,6 +19,7 @@ from collective.eeafaceted.collectionwidget.interfaces import ICollectionCategor
 from collective.eeafaceted.collectionwidget.utils import _updateDefaultCollectionFor
 from collective.eeafaceted.dashboard.interfaces import ICountableTab
 from collective.eeafaceted.dashboard.utils import enableFacetedDashboardFor
+from collective.iconifiedcategory.utils import calculate_category_id
 from collective.querynextprev.interfaces import INextPrevNotNavigable
 from collective.quickupload.browser.quickupload_settings import IQuickUploadControlPanel
 from dexterity.localroles.utils import add_fti_configuration
@@ -573,76 +574,41 @@ def setup_iconified_categories(portal):
         )
     ccc = portal["annexes_types"]
 
+    def _create_category_group(oid, title, **kwargs):
+        if oid not in ccc:
+            group = api.content.create(
+                type="ContentCategoryGroup",
+                title=title,
+                container=ccc,
+                id=oid,
+                **kwargs
+            )
+            do_transitions(group, ["show_internally"])
+            alsoProvides(group, IProtectedItem)
+        else:
+            group = ccc[oid]
+        return group
+
+    activated = {
+        "to_be_printed_activated": True,
+        "signed_activated": True,
+        "approved_activated": True,
+    }
+
     # Content Category Group for classification folders
-    if "annexes" not in ccc:
-        annexes_category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title=_("Folders Appendix Files"),
-            container=ccc,
-            id="annexes",
-        )
-        do_transitions(annexes_category_group, ["show_internally"])
-        alsoProvides(annexes_category_group, IProtectedItem)
-    else:
-        annexes_category_group = ccc["annexes"]
-
+    _create_category_group("annexes", _("Folders Appendix Files"))
     # Content Category Group for dms main files in incoming mails
-    if "incoming_dms_files" not in ccc:
-        incoming_dms_files_category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title=_("Incoming DMS Files"),
-            container=ccc,
-            id="incoming_dms_files",
-        )
-        do_transitions(incoming_dms_files_category_group, ["show_internally"])
-        alsoProvides(incoming_dms_files_category_group, IProtectedItem)
-    else:
-        incoming_dms_files_category_group = ccc["incoming_dms_files"]
-
+    incoming_dms_files_category_group = _create_category_group(
+        "incoming_dms_files", _("Incoming DMS Files"))
     # Content Category Group for appendix files in incoming mails
-    if "incoming_appendix_files" not in ccc:
-        incoming_appendix_files_category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title=_("Incoming Appendix Files"),
-            container=ccc,
-            id="incoming_appendix_files",
-        )
-        do_transitions(incoming_appendix_files_category_group, ["show_internally"])
-        alsoProvides(incoming_appendix_files_category_group, IProtectedItem)
-    else:
-        incoming_appendix_files_category_group = ccc["incoming_appendix_files"]
-
+    incoming_appendix_files_category_group = _create_category_group(
+        "incoming_appendix_files", _("Incoming Appendix Files"))
     # Content Category Group for dms main files in outgoing mails
-    if "outgoing_dms_files" not in ccc:
-        outgoing_dms_files_category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title=_("Outgoing DMS Files"),
-            container=ccc,
-            id="outgoing_dms_files",
-            to_be_printed_activated=True,
-            signed_activated=True,
-            approved_activated=True,
-        )
-        do_transitions(outgoing_dms_files_category_group, ["show_internally"])
-        alsoProvides(outgoing_dms_files_category_group, IProtectedItem)
-    else:
-        outgoing_dms_files_category_group = ccc["outgoing_dms_files"]
-
+    outgoing_dms_files_category_group = _create_category_group(
+        "outgoing_dms_files", _("Outgoing DMS Files"), **activated)
     # Content Category Group for appendix files in outgoing mails
-    if "outgoing_appendix_files" not in ccc:
-        outgoing_appendix_files_category_group = api.content.create(
-            type="ContentCategoryGroup",
-            title=_("Outgoing Appendix Files"),
-            container=ccc,
-            id="outgoing_appendix_files",
-            to_be_printed_activated=True,
-            signed_activated=True,
-            approved_activated=True,
-        )
-        do_transitions(outgoing_appendix_files_category_group, ["show_internally"])
-        alsoProvides(outgoing_appendix_files_category_group, IProtectedItem)
-    else:
-        outgoing_appendix_files_category_group = ccc["outgoing_appendix_files"]
+    outgoing_appendix_files_category_group = _create_category_group(
+        "outgoing_appendix_files", _("Outgoing Appendix Files"), **activated)
 
     # Create ContentCategory objects inside each category group
     images_dir = pkg_resources.resource_filename('imio.dms.mail', 'profiles/examples/images')
@@ -2653,6 +2619,8 @@ def add_templates(site):
                 ret.append(dic)
         return ret
 
+    category_id = calculate_category_id(site["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"])
+
     data = {
         10: {
             "title": _(u"Mail listing template"),
@@ -2745,6 +2713,7 @@ def add_templates(site):
                     {"name": u"actions", "value": u""},
                     {"name": u"extras", "value": u"UID,PATH,CTX_PATH,CASE"},
                 ],
+                "default_content_category": category_id,
             },
         },
         90: {"title": _(u"Style template"), "type": "StyleTemplate", "trans": ["show_internally"]},
@@ -2826,6 +2795,7 @@ def add_templates(site):
                 "style_template": [cids[90].UID()],
                 "mailing_loop_template": cids[150].UID(),
                 "rename_page_styles": False,
+                "default_content_category": category_id,
             },
         },
         #                       'context_variables': [{'name': u'do_mailing', 'value': u'1'}]}},
@@ -2851,6 +2821,7 @@ def add_templates(site):
                     {"name": u"PVS", "value": u"False"},
                 ],
                 "rename_page_styles": False,
+                "default_content_category": category_id,
             },
         },
     }

--- a/imio/dms/mail/setuphandlers.py
+++ b/imio/dms/mail/setuphandlers.py
@@ -57,6 +57,7 @@ from imio.pyutils.utils import safe_encode
 from plone import api
 from plone.app.controlpanel.markup import MarkupControlPanelAdapter
 from plone.dexterity.interfaces import IDexterityFTI
+from plone.namedfile.file import NamedBlobImage
 from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.ActionInformation import Action
@@ -642,6 +643,42 @@ def setup_iconified_categories(portal):
         alsoProvides(outgoing_appendix_files_category_group, IProtectedItem)
     else:
         outgoing_appendix_files_category_group = ccc["outgoing_appendix_files"]
+
+    # Create ContentCategory objects inside each category group
+    images_dir = pkg_resources.resource_filename('imio.dms.mail', 'profiles/examples/images')
+
+    def _create_category(group, oid, title, img, **kwargs):
+        if oid not in group:
+            icon_path = os.path.join(images_dir, img)
+            with open(icon_path, "rb") as fl:
+                icon = NamedBlobImage(fl.read(), filename=img)
+            cat = api.content.create(
+                type="ContentCategory",
+                title=title,
+                description=u"",
+                container=group,
+                icon=icon,
+                id=oid,
+                predefined_title=title,
+                **kwargs
+            )
+            alsoProvides(cat, IProtectedItem)
+
+    # Content Categories for incoming mails
+    _create_category(incoming_dms_files_category_group, "incoming-dms-file", _("Incoming DMS File"),
+                     u"file-alt-regular.png")
+    _create_category(incoming_appendix_files_category_group, "incoming-appendix-file", _("Incoming Appendix File"),
+                     u"attach.png")
+
+    # Content Categories for outgoing mails
+    _create_category(outgoing_dms_files_category_group, "outgoing-dms-file", _("Outgoing DMS File"),
+                     u"file-alt-regular.png", to_sign=True, to_approve=True)
+    _create_category(outgoing_dms_files_category_group, "outgoing-scanned-dms-file",
+                     _("Outgoing Scanned DMS File"), u"file-alt-regular.png", to_sign=True, to_approve=False)
+    _create_category(outgoing_appendix_files_category_group, "outgoing-appendix-file",
+                     _("Outgoing Appendix File"), u"attach.png", to_sign=False, to_approve=False)
+    _create_category(outgoing_appendix_files_category_group, "outgoing-signable-appendix-file",
+                     _("Outgoing Signable Appendix File"), u"attach-esign.png", to_sign=True, to_approve=True)
 
 
 def createStateCollections(folder, content_type):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added icon support for mail file categories and automated creation of category entries during setup.
  * Configured outgoing categories with sign/approve activation flags and protection marking.

* **Refactor**
  * Centralized category-group creation and moved default content-category assignment earlier in template setup for more consistent defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->