### PR TITLE
Paraf 468/wfa

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Changelog
   [sgeulette]
 - Updated incoming mail_types and send_modes examples.
   [chris-adam, sgeulette]
+- Fixed duplicate transitions on wfa reapply in migration 3.1.
+  [chris-adam]
 
 3.1.4 (2026-05-29)
 ------------------

--- a/imio/dms/mail/tests/test_wfadaptations.py
+++ b/imio/dms/mail/tests/test_wfadaptations.py
@@ -4,6 +4,7 @@
 from collective.contact.plonegroup.config import get_registry_functions
 from collective.contact.plonegroup.config import get_registry_organizations
 from collective.iconifiedcategory.utils import calculate_category_id
+from collective.wfadaptations.api import apply_from_registry
 from datetime import datetime
 from imio.dms.mail import PRODUCT_DIR
 from imio.dms.mail.interfaces import IOMApproval
@@ -16,6 +17,7 @@ from imio.dms.mail.utils import sub_create
 from imio.dms.mail.vocabularies import encodeur_active_orgs
 from imio.dms.mail.wfadaptations import IMPreManagerValidation
 from imio.helpers.content import get_object
+from imio.helpers.setup import load_workflow_from_package
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -510,6 +512,56 @@ class TestOMToApproveAdaptation(BaseTestWFAdaptations):
         )
         self.common_tests()
 
+    def _check_om_to_approve_n_plus_1_reapply(self):
+        """Reset the OM workflow and reapply every adaptation from the registry.
+
+        The workflow states and the transitions available on each state must be
+        identical before and after the reset+reapply
+        """
+        # snapshot the workflow as produced by the normal (single) application
+        before = {state.getId(): sorted(state.transitions) for state in self.omw.states.values()}
+        # no state must hold a duplicated transition
+        for state in self.omw.states.values():
+            transitions = list(state.transitions)
+            self.assertEqual(len(transitions), len(set(transitions)), state.getId())
+        # reset workflow
+        self.assertTrue(load_workflow_from_package("outgoingmail_workflow", "imio.dms.mail:default"))
+        # reapply every adaptation from the registry
+        _success, errors = apply_from_registry(reapply=True)
+        self.assertEqual(errors, 0)
+        after = {state.getId(): sorted(state.transitions) for state in self.omw.states.values()}
+        self.assertEqual(before, after)
+        # no state must hold a duplicated transition
+        for state in self.omw.states.values():
+            transitions = list(state.transitions)
+            self.assertEqual(len(transitions), len(set(transitions)), state.getId())
+        # 'propose_to_approve' must appear exactly once on each n+1 chain state
+        for st_id in ("proposed_to_n_plus_1", "validated"):
+            transitions = list(self.omw.states[st_id].transitions)
+            self.assertEqual(transitions.count("propose_to_approve"), 1, st_id)
+        # the 'validated' state must not get a back_to_validated self-transition
+        self.assertNotIn("back_to_validated", self.omw.states["validated"].transitions)
+
+    def test_OMToApprove_after_n_plus_1_reapply(self):
+        """Test adaptations are reapplied from registry (n+1 applied first)."""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_n_plus_1_wfadaptation", run_dependencies=False
+        )
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self._check_om_to_approve_n_plus_1_reapply()
+
+    def test_OMToApprove_before_n_plus_1_reapply(self):
+        """Test adaptations are reapplied from registry (to_approve applied first)."""
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_to_approve_wfadaptation", run_dependencies=False
+        )
+        self.portal.portal_setup.runImportStepFromProfile(
+            "profile-imio.dms.mail:singles", "imiodmsmail-om_n_plus_1_wfadaptation", run_dependencies=False
+        )
+        self._check_om_to_approve_n_plus_1_reapply()
+
 
 class TestOMServiceValidation1(unittest.TestCase):
 
@@ -634,6 +686,25 @@ class TestOMServiceValidation1(unittest.TestCase):
         lst = api.portal.get_registry_record("imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_remark_states")
         self.assertIn("proposed_to_n_plus_1", lst)
         self.assertIn("validated", lst)
+
+    def test_OMServiceValidation_reapply(self):
+        """Test adaptations are reapplied from registry."""
+        before = {state.getId(): sorted(state.transitions) for state in self.omw.states.values()}
+        self.assertTrue(load_workflow_from_package("outgoingmail_workflow", "imio.dms.mail:default"))
+        _success, errors = apply_from_registry(
+            reapply=True, name=u"imio.dms.mail.wfadaptations.OMServiceValidation"
+        )
+        self.assertEqual(errors, 0)
+        after = {state.getId(): sorted(state.transitions) for state in self.omw.states.values()}
+        self.assertEqual(before, after)
+        # 'set_validated' must appear exactly once on proposed_to_n_plus_1
+        self.assertEqual(list(self.omw.states["proposed_to_n_plus_1"].transitions).count("set_validated"), 1)
+        # 'validated' must not get a back_to_validated self-transition
+        self.assertNotIn("back_to_validated", self.omw.states["validated"].transitions)
+        # no state must hold a duplicated transition
+        for state in self.omw.states.values():
+            transitions = list(state.transitions)
+            self.assertEqual(len(transitions), len(set(transitions)), state.getId())
 
     def test_dmsdocument_modified_subscriber1(self):
         """Test only treating_groups change while the state is on a service validation level"""

--- a/imio/dms/mail/wfadaptations.py
+++ b/imio/dms/mail/wfadaptations.py
@@ -644,7 +644,7 @@ class OMServiceValidation(WorkflowAdaptationBase):
         val_back_tr_id = "back_to_validated"
 
         transitions = [tr for (st, tr) in wf_from_to["from"]] + [tr for (st, tr) in wf_from_to["to"]]
-        to_states = [st for (st, tr) in wf_from_to["to"]]
+        to_states = [st for (st, tr) in wf_from_to["to"] if st != val_state_id]
         # store current level in dms_config
         # wf_from_to['to'] += [(new_state_id, propose_tr_id)]
         # set_dms_config(['wf_from_to', 'dmsoutgoingmail', 'n_plus'], wf_from_to)
@@ -655,9 +655,9 @@ class OMServiceValidation(WorkflowAdaptationBase):
             return False, "State {} already in workflow".format(new_state_id)
         wf.states.addState(new_state_id)
         state = wf.states[new_state_id]
-        new_state_transitions = transitions
+        new_state_transitions = list(transitions)
         if val_set_tr_id not in new_state_transitions:
-            new_state_transitions += [val_set_tr_id]
+            new_state_transitions.append(val_set_tr_id)
         state.setProperties(
             title=parameters["state_title"].encode("utf8"), description="", transitions=new_state_transitions
         )
@@ -677,11 +677,9 @@ class OMServiceValidation(WorkflowAdaptationBase):
         # add validated state
         wf.states.addState(val_state_id)
         val_state = wf.states[val_state_id]
-        val_transitions = list(transitions)
+        val_transitions = [tr for tr in transitions if tr != val_set_tr_id]
         if back_tr_id not in val_transitions:
-            val_transitions += [back_tr_id]
-        if val_set_tr_id in new_state_transitions:
-            val_transitions.remove(val_set_tr_id)
+            val_transitions.append(back_tr_id)
         if not parameters["validated_from_created"]:
             val_transitions.remove("back_to_creation")
         val_state.setProperties(title="om_validated", description="", transitions=val_transitions)
@@ -1156,7 +1154,11 @@ class OMToApproveAdaptation(WorkflowAdaptationBase):
             state.transitions = tuple(transitions)
         if already_applied == "n_plus":
             for st in ("proposed_to_n_plus_1", "validated"):
+                if st not in wf.states:
+                    continue
                 transitions = list(wf.states[st].transitions)
+                if to_tr_id in transitions:
+                    continue
                 transitions.append(to_tr_id)
                 wf.states[st].transitions = tuple(transitions)
 

--- a/imio/dms/mail/wfadaptations.py
+++ b/imio/dms/mail/wfadaptations.py
@@ -655,8 +655,11 @@ class OMServiceValidation(WorkflowAdaptationBase):
             return False, "State {} already in workflow".format(new_state_id)
         wf.states.addState(new_state_id)
         state = wf.states[new_state_id]
+        new_state_transitions = transitions
+        if val_set_tr_id not in new_state_transitions:
+            new_state_transitions += [val_set_tr_id]
         state.setProperties(
-            title=parameters["state_title"].encode("utf8"), description="", transitions=transitions + [val_set_tr_id]
+            title=parameters["state_title"].encode("utf8"), description="", transitions=new_state_transitions
         )
         # permissions
         perms = {
@@ -674,7 +677,11 @@ class OMServiceValidation(WorkflowAdaptationBase):
         # add validated state
         wf.states.addState(val_state_id)
         val_state = wf.states[val_state_id]
-        val_transitions = list(transitions) + [back_tr_id]
+        val_transitions = list(transitions)
+        if back_tr_id not in val_transitions:
+            val_transitions += [back_tr_id]
+        if val_set_tr_id in new_state_transitions:
+            val_transitions.remove(val_set_tr_id)
         if not parameters["validated_from_created"]:
             val_transitions.remove("back_to_creation")
         val_state.setProperties(title="om_validated", description="", transitions=val_transitions)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate workflow transitions when reapplying workflow adaptations during the 3.1 migration, ensuring outgoing-mail approval and service validation flows don’t repeat edges on reset/reapply.

* **Tests**
  * Added “reapply from registry” test coverage that snapshots transitions per state and verifies they remain identical, with key transitions appearing exactly once and no unwanted back transitions introduced.

* **Documentation**
  * Updated the 3.1.5 (unreleased) changelog entry for this fix (credit: chris-adam).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->