### PR TITLE
PARAF-477: Fixed AttributeError (get_person) raised in is_hp_used_in_signer_rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Changelog
   [sgeulette]
 - Updated incoming mail_types and send_modes examples.
   [chris-adam, sgeulette]
+- Fixed AttributeError (get_person) raised in is_hp_used_in_signer_rules (PARAF-477).
+  [chris-adam]
 
 3.1.4 (2026-05-29)
 ------------------

--- a/imio/dms/mail/content/behaviors.py
+++ b/imio/dms/mail/content/behaviors.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.contact.core.interfaces import IHeldPosition
 from collective.contact.plonegroup import _ as _ccp
 from collective.contact.plonegroup.behaviors import IPlonegroupUserLink
 from collective.z3cform.datagridfield.registry import DictRow
@@ -390,7 +391,7 @@ class UsagesSignerRulesValidator(validator.SimpleFieldValidator):
 
     def validate(self, value, force=False):
         super(UsagesSignerRulesValidator, self).validate(value, force=force)
-        if not IPersonnelContact.providedBy(self.context):
+        if not IHeldPosition.providedBy(self.context):
             return
         if is_hp_used_in_signer_rules(self.context, value or []):
             raise Invalid(_(

--- a/imio/dms/mail/content/behaviors.py
+++ b/imio/dms/mail/content/behaviors.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from collective.contact.core.interfaces import IHeldPosition
 from collective.contact.plonegroup import _ as _ccp
 from collective.contact.plonegroup.behaviors import IPlonegroupUserLink
 from collective.z3cform.datagridfield.registry import DictRow
@@ -391,7 +390,8 @@ class UsagesSignerRulesValidator(validator.SimpleFieldValidator):
 
     def validate(self, value, force=False):
         super(UsagesSignerRulesValidator, self).validate(value, force=force)
-        if not IHeldPosition.providedBy(self.context):
+        if self.context.portal_type == "person" or not IPersonnelContact.providedBy(self.context):
+            # on addition or outside personnel, we skip check
             return
         if is_hp_used_in_signer_rules(self.context, value or []):
             raise Invalid(_(

--- a/imio/dms/mail/tests/test_behaviors.py
+++ b/imio/dms/mail/tests/test_behaviors.py
@@ -36,6 +36,7 @@ class TestBehaviors(unittest.TestCase, ImioTestHelpers):
         self.change_user("siteadmin")
         activate_signing(self.portal)
         self.pw = self.portal.portal_workflow
+        self.dir = self.portal["contacts"]
         self.pgof = self.portal["contacts"]["plonegroup-organization"]
         self.pf = self.portal["contacts"]["personnel-folder"]
 
@@ -455,6 +456,9 @@ class TestBehaviors(unittest.TestCase, ImioTestHelpers):
         # Add-form scenario: context is the Person container
         person_validator = UsagesSignerRulesValidator(bourgmestre, request, None, field, None)
         self.assertIsNone(person_validator.validate(["signer"]))
+        outside_hp_validator = UsagesSignerRulesValidator(
+            self.dir["sergerobinet"]["agent-swde"], request, None, field, None)
+        self.assertIsNone(outside_hp_validator.validate(["signer"]))
 
         # Edit scenario: context is the HeldPosition
         api.portal.set_registry_record(rk_rules, [{

--- a/imio/dms/mail/tests/test_behaviors.py
+++ b/imio/dms/mail/tests/test_behaviors.py
@@ -4,7 +4,10 @@ from datetime import datetime
 from imio.dms.mail import _tr
 from imio.dms.mail import PRODUCT_DIR
 from imio.dms.mail.content.behaviors import ISigningBehavior
+from imio.dms.mail.content.behaviors import IUsagesBehavior
+from imio.dms.mail.content.behaviors import UsagesSignerRulesValidator
 from imio.dms.mail.Extensions.demo import activate_signing
+from imio.dms.mail.interfaces import IPersonnelContact
 from imio.dms.mail.testing import DMSMAIL_INTEGRATION_TESTING
 from imio.dms.mail.utils import sub_create
 from imio.helpers.test_helpers import ImioTestHelpers
@@ -440,3 +443,33 @@ class TestBehaviors(unittest.TestCase, ImioTestHelpers):
         }
         errors = tpl_invariants.validate(data)
         self.assertEqual(errors, ())
+
+    def test_usages_signer_rules_validator(self):
+        bourgmestre = self.pf["bourgmestre"]
+        bourgmestre_hp = bourgmestre["bourgmestre"]
+        self.assertTrue(IPersonnelContact.providedBy(bourgmestre))
+        field = IUsagesBehavior["usages"]
+        request = self.portal.REQUEST
+        rk_rules = "imio.dms.mail.browser.settings.IImioDmsMailConfig.omail_signer_rules"
+
+        # Add-form scenario: context is the Person container
+        person_validator = UsagesSignerRulesValidator(bourgmestre, request, None, field, None)
+        self.assertIsNone(person_validator.validate(["signer"]))
+
+        # Edit scenario: context is the HeldPosition
+        api.portal.set_registry_record(rk_rules, [{
+            "number": 1,
+            "signer": bourgmestre_hp.UID(),
+            "esign": True,
+            "approvings": [u"_empty_"],
+            "editor": False,
+            "treating_groups": [],
+            "mail_types": [],
+            "send_modes": [],
+            "tal_condition": None,
+        }])
+        hp_validator = UsagesSignerRulesValidator(bourgmestre_hp, request, None, field, None)
+        self.assertRaises(Invalid, hp_validator.validate, [])
+        # Keeping the signer usage: no conflict.
+        self.assertIsNone(hp_validator.validate(["signer"]))
+        api.portal.set_registry_record(rk_rules, [])


### PR DESCRIPTION
## Summary
When manually creating a held position ("fonction occupée") for a user, the `UsagesSignerRulesValidator` ran on the Person container during the add-form and called `is_hp_used_in_signer_rules`, which invokes `get_person` on a non-HeldPosition context, raising `AttributeError: get_person`. The validator now guards on `IHeldPosition.providedBy(self.context)` instead of `IPersonnelContact`, so it only runs against an actual HeldPosition.

## Ticket
PARAF-477 — https://support-imio.atlassian.net/browse/PARAF-477

## Pre-PR checks
- [x] CHANGES up to date
- [x] Tests exist for new code
- [x] Diff matches ticket
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (N/A — code-only change)
- [x] Commits reference ticket / mergeable

## Commits
6c30a8b7 PARAF-477: Fixed AttributeError (get_person) raised in is_hp_used_in_signer_rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an `AttributeError` raised during signer rule validation.
  * Updated signer/approver usage validation so the “usage still referenced” check is skipped in additional person-related contexts, preventing incorrect `Invalid` results.

* **Tests**
  * Added coverage for signer rule validation across add-form and edit-form scenarios, including registry-configured allowed usages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->