### PR TITLE
DMS-1216: Updated  classification tree cache invalidation to the new …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.1.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Updated `Extensions/demo.py` classification tree cache invalidation to the new
+  `iterate_over_tree_data` cache key (DMS-1216).
+  [chris-adam]
 
 
 3.1.5 (2026-06-19)

--- a/imio/dms/mail/Extensions/demo.py
+++ b/imio/dms/mail/Extensions/demo.py
@@ -532,14 +532,14 @@ def clean_examples(self, doit="1"):
         if doit:
             api.content.delete(obj=brain._unrestrictedGetObject())
     # Delete categories
-    caching.invalidate_cache("collective.classification.tree.utils.iterate_over_tree", portal["tree"].UID())
+    caching.invalidate_cache("collective.classification.tree.utils.iterate_over_tree_data", portal["tree"].UID())
     res = iterate_over_tree(portal["tree"])
     for category in reversed(res):
         log_list(out, "Deleting category '%s - %s'" % (safe_encode(category.identifier), safe_encode(category.title)))
         if doit:
             api.content.delete(objects=[category])
     if doit:
-        caching.invalidate_cache("collective.classification.tree.utils.iterate_over_tree", portal["tree"].UID())
+        caching.invalidate_cache("collective.classification.tree.utils.iterate_over_tree_data", portal["tree"].UID())
         portal.portal_properties.site_properties.enable_link_integrity_checks = True
     # Create test om
     if doit:


### PR DESCRIPTION
… cache key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category cleanup so classification tree cache invalidation refreshes correctly during deletion, keeping classification data accurate.
* **Documentation**
  * Updated the 3.1.6 (unreleased) changelog entry to reflect the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->