### PR TITLE
PARAF-412: Displayed iconified icons below outgoing files title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changelog
   [chris-adam]
 - Considered seal when checking if a signer is defined on a sub/template.
   [sgeulette]
+- Displayed iconified icons below outgoing files title (PARAF-412).
+  [chris-adam]
 
 3.1.5 (2026-06-19)
 ------------------

--- a/imio/dms/mail/browser/iconified_category.py
+++ b/imio/dms/mail/browser/iconified_category.py
@@ -8,6 +8,7 @@ from collective.iconifiedcategory.browser.actionview import SignedChangeView as 
 from collective.iconifiedcategory.browser.tabview import ApprovedColumn as BaseApprovedColumn
 from collective.iconifiedcategory.browser.tabview import SignedColumn as BaseSignedColumn
 from imio.dms.mail.adapters import OMApprovalAdapter
+from imio.dms.mail.interfaces import IOMApproval
 from imio.dms.mail.utils import get_allowed_omf_content_types
 from imio.dms.mail.utils import logger  # noqa F401
 # from imio.esign.audit import audit as esign_audit
@@ -30,6 +31,61 @@ from zope.i18n import translate
  'signers': [('dirg', u'Maxime DG ()', u'')]
 }
 """  # noqa
+
+
+def approved_display(mail, fileobj):
+    """Return ``(css_class, title)`` for the *approved* icon shown, non-clickable,
+       on an outgoing-mail file's view page (viewlet)."""
+    approval = IOMApproval(mail)
+    state = api.content.get_state(mail)
+    uid = fileobj.UID()
+    userid = api.user.get_current().getId()
+    classes = ["iconified-approved"]
+    to_approve = getattr(fileobj, "to_approve", True)
+
+    if approval.is_state_before_approve(state=state):
+        if not to_approve:
+            return " ".join(classes + ["to-approve"]), u"Deactivated for approval"
+        return " ".join(classes + ["active", "to-approve"]), u"Activated for approval"
+    if not to_approve:  # state >= to_approve and to_approve is False
+        return " ".join(classes + ["to-approve"]), u"Deactivated for approval"
+    if state == "to_approve":
+        approver_number = approval.get_approver_nb(userid)
+        if approval.can_approve(userid, uid):
+            if approval.is_file_approved(uid, nb=approver_number):
+                return " ".join(classes + ["active"]), u"Already approved"
+            return " ".join(classes), u"Waiting for your approval"
+        elif userid in approval.approvers:
+            current_nb = approval.current_nb
+            if approver_number is not None and current_nb is not None and approver_number > current_nb:
+                return (" ".join(classes + ["waiting"]),
+                        u"Waiting for other approval before you can approve")
+    if approval.is_file_approved(uid):
+        return " ".join(classes + ["totally-approved"]), u"Totally approved"
+    elif approval.is_file_approved(uid, totally=False):
+        return (" ".join(classes + ["partially-approved"]),
+                u"Partially approved. Still waiting for other approval(s)")
+    return " ".join(classes + ["cant-approve"]), u"Waiting for the first approval"
+
+
+def signed_display(mail, fileobj):
+    """Return the *signed* icon css_class shown, non-clickable, on an
+       outgoing-mail file's view page (viewlet)."""
+    state = api.content.get_state(mail)
+    classes = ["iconified-signed"]
+    to_sign = getattr(fileobj, "to_sign", True)
+    signed = getattr(fileobj, "signed", False)
+
+    if state not in ("to_approve", "to_print", "to_be_signed", "signed", "sent"):
+        if not to_sign:
+            return " ".join(classes + ["deactivated"])
+        return " ".join(classes)
+    elif not to_sign:  # state >= to_approve and to_sign is False
+        return " ".join(classes + ["deactivated"])
+    # state >= to_approve and to_sign is True
+    if signed:
+        classes.append("active")
+    return " ".join(classes)
 
 
 class ApprovedColumn(BaseApprovedColumn):

--- a/imio/dms/mail/browser/overrides.zcml
+++ b/imio/dms/mail/browser/overrides.zcml
@@ -246,4 +246,28 @@
         />
     </unconfigure>
 
+    <unconfigure package="collective.iconifiedcategory" zcml:condition="installed collective.iconifiedcategory">
+        <browser:viewlet
+         name="iconifiedcategory.item.infos"
+         for="collective.iconifiedcategory.behaviors.iconifiedcategorization.IIconifiedCategorizationMarker"
+         manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+         layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
+         class="collective.iconifiedcategory.browser.viewlets.CategorizedItemInfoViewlet"
+         template="browser/templates/categorized-item-info-viewlet.pt"
+         permission="zope2.View"
+        />
+    </unconfigure>
+
+    <configure package="collective.iconifiedcategory" zcml:condition="installed collective.iconifiedcategory">
+        <browser:viewlet
+            name="iconifiedcategory.item.infos"
+            for="collective.iconifiedcategory.behaviors.iconifiedcategorization.IIconifiedCategorizationMarker"
+            manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+            layer="collective.iconifiedcategory.interfaces.ICollectiveIconifiedCategoryLayer"
+            class="imio.dms.mail.browser.viewlets.DmsCategorizedItemInfoViewlet"
+            template="browser/templates/categorized-item-info-viewlet.pt"
+            permission="zope2.View"
+            />
+    </configure>
+
 </configure>

--- a/imio/dms/mail/browser/viewlets.py
+++ b/imio/dms/mail/browser/viewlets.py
@@ -1,16 +1,21 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_parent
 from collective.contact.core.browser.address import get_address
 from collective.contact.widget.interfaces import IContactContent
 from collective.dms.basecontent.browser.viewlets import VersionsViewlet
 from collective.eeafaceted.batchactions.browser.viewlets import BatchActionsViewlet
+from collective.iconifiedcategory.browser.viewlets import CategorizedItemInfoViewlet
 from collective.messagesviewlet.browser.messagesviewlet import GlobalMessagesViewlet
 from collective.messagesviewlet.message import generate_uid
 from collective.messagesviewlet.message import PseudoMessage
 from collective.task.browser.viewlets import TaskParentViewlet
+from imio.dms.mail.browser.iconified_category import approved_display
+from imio.dms.mail.browser.iconified_category import signed_display
 from imio.dms.mail.browser.table import IMVersionsTable
 from imio.dms.mail.browser.table import OMVersionsTable
 from imio.dms.mail.browser.views import ImioSessionsListingView
 from imio.dms.mail.dmsmail import IImioDmsOutgoingMail
+from imio.dms.mail.interfaces import IOMApproval
 from imio.esign.browser.views import FacetedSessionInfoViewlet
 from imio.esign.browser.views import ItemSessionInfoViewlet
 from imio.helpers.content import richtextval
@@ -85,6 +90,47 @@ class OMVersionsViewlet(VersionsViewlet):
 
     portal_type = "dmsommainfile"
     __table__ = OMVersionsTable
+
+
+class DmsCategorizedItemInfoViewlet(CategorizedItemInfoViewlet):
+    """Category-status icons below the title of a categorized item."""
+
+    @property
+    def _mail(self):
+        return aq_parent(self.context)
+
+    @property
+    def _is_om(self):
+        return IImioDmsOutgoingMail.providedBy(self._mail)
+
+    @property
+    def _approved_display(self):
+        if not hasattr(self, "_approved_display_cache"):
+            self._approved_display_cache = approved_display(self._mail, self.context)
+        return self._approved_display_cache
+
+    def show(self, element, attr_prefix):
+        show = super(DmsCategorizedItemInfoViewlet, self).show(element, attr_prefix)
+        # Hide the approval icon when no approver is configured for this mail,
+        # mirroring OMVersionsTable.setUpColumns which drops the ApprovedColumn.
+        if show and attr_prefix == "approved" and self._is_om:
+            return bool(IOMApproval(self._mail).approvers)
+        return show
+
+    def _css_for_approved(self, element):
+        if not self._is_om:
+            return super(DmsCategorizedItemInfoViewlet, self)._css_for_approved(element)
+        return self._approved_display[0]
+
+    def _title_for_approved(self, element):
+        if not self._is_om:
+            return super(DmsCategorizedItemInfoViewlet, self)._title_for_approved(element)
+        return self._approved_display[1]
+
+    def _css_for_signed(self, element):
+        if not self._is_om:
+            return super(DmsCategorizedItemInfoViewlet, self)._css_for_signed(element)
+        return signed_display(self._mail, self.context)
 
 
 class PrettyLinkTitleViewlet(ViewletBase):

--- a/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
+++ b/imio/dms/mail/skins/imio_dms_mail/imiodmsmail.css.dtml
@@ -650,6 +650,56 @@ body.template-facetednavigation_view.portaltype-classificationsubfolder #content
   color: #75ad0a;
 }
 
+/* CategorizedItemInfoViewlet */
+#content .categorized_elements_details span.iconified-signed::before {
+  content: "\f205";  /* toggle-on */
+  font-weight: bold !important;
+}
+#content .categorized_elements_details span.iconified-signed.deactivated::before {
+  content: "\f204";  /* toggle-off */
+  font-weight: bold !important;
+}
+#content .categorized_elements_details span.iconified-signed.deactivated {
+  color: #999;
+}
+#content .categorized_elements_details span.iconified-signed.active::before {
+  content: "\f044";  /* pen-to-square */
+  font-weight: bold !important;
+}
+
+#content .categorized_elements_details span.iconified-approved.to-approve::before {
+  content: "\f204";  /* toggle-off */
+  font-weight: bold !important;
+}
+#content .categorized_elements_details span.iconified-approved.to-approve {
+  color: #999;
+}
+#content .categorized_elements_details span.iconified-approved.active.to-approve::before {
+  content: "\f205";  /* toggle-on */
+  font-weight: bold !important;
+}
+#content .categorized_elements_details span.iconified-approved.active.to-approve {
+  color: #EA0000;
+}
+#content .categorized_elements_details span.iconified-approved.cant-approve::before {
+  content: "\f254";  /* hourglass */
+  color: black;
+  font-weight: initial;
+}
+#content .categorized_elements_details span.iconified-approved.waiting::before {
+  content: "\f254";  /* hourglass */
+  color: #EA0000;
+  font-weight: initial;
+}
+#content .categorized_elements_details span.iconified-approved.partially-approved::before {
+  content: "\f252";  /* hourglass-half */
+  color: #FFB627;
+}
+#content .categorized_elements_details span.iconified-approved.totally-approved::before {
+  content: "\f560";  /* check-double */
+  color: #75ad0a;
+}
+
 .template-personnel-listing td.td_cell_hps li span.signer-icon::before {
     content: "\f044";
     font-family: "Font Awesome 5 Free";

--- a/imio/dms/mail/tests/test_browser_iconified_category.py
+++ b/imio/dms/mail/tests/test_browser_iconified_category.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from collective.dms.basecontent.browser.listing import CategorizedContent
 from collective.dms.mailcontent.dmsmail import internalReferenceOutgoingMailDefaultValue
+from collective.iconifiedcategory.browser.viewlets import CategorizedItemInfoViewlet
 from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import datetime
 from imio.dms.mail import PRODUCT_DIR
@@ -9,6 +10,8 @@ from imio.dms.mail.browser.iconified_category import ApprovedChangeView
 from imio.dms.mail.browser.iconified_category import ApprovedColumn
 from imio.dms.mail.browser.iconified_category import SignedChangeView
 from imio.dms.mail.browser.iconified_category import SignedColumn
+from imio.dms.mail.browser.viewlets import DmsCategorizedItemInfoViewlet
+from imio.dms.mail.interfaces import IOMApproval
 from imio.dms.mail.testing import DMSMAIL_INTEGRATION_TESTING
 from imio.dms.mail.utils import clean_borg_cache
 from imio.dms.mail.utils import DummyView
@@ -368,3 +371,82 @@ class TestBrowserIconifiedCategory(unittest.TestCase, ImioTestHelpers):
         self.assertEqual(view._get_next_values(old_values), (0, {"to_sign": True, "signed": False}))
         old_values = {"to_sign": True, "signed": False}
         self.assertEqual(view._get_next_values(old_values), (1, {"to_sign": True, "signed": True}))
+
+    def _info_viewlet(self, fileobj):
+        return DmsCategorizedItemInfoViewlet(fileobj, self.portal.REQUEST, None, None)
+
+    def test_item_info_viewlet_om_icons(self):
+        """The below-title viewlet reproduces the OM approved/signed icons
+        (non-clickable, no '(click to ...)' hints) on outgoing-mail files."""
+        self.change_user("admin")
+        el = self.omail2.categorized_elements[self.file2.UID()]
+        self.assertTrue(self._info_viewlet(self.file2)._is_om)
+        # created (before approve), deactivated for approval
+        self.file2.to_approve = False
+        v = self._info_viewlet(self.file2)
+        self.assertEqual(v._css_for_approved(el), "iconified-approved to-approve")
+        self.assertEqual(v._title_for_approved(el), u"Deactivated for approval")
+        # created, activated for approval
+        self.file2.to_approve = True
+        v = self._info_viewlet(self.file2)
+        self.assertEqual(v._css_for_approved(el), "iconified-approved active to-approve")
+        self.assertEqual(v._title_for_approved(el), u"Activated for approval")
+        # signed icon: to_sign True -> plain (toggle-on), to_sign False -> deactivated
+        self.file2.to_sign = True
+        self.assertEqual(self._info_viewlet(self.file2)._css_for_signed(el), "iconified-signed")
+        self.file2.to_sign = False
+        self.assertEqual(self._info_viewlet(self.file2)._css_for_signed(el), "iconified-signed deactivated")
+
+    def test_item_info_viewlet_render_empty_when_untracked(self):
+        """No crash (500) when the item is not tracked in categorized_elements."""
+        self.change_user("siteadmin")
+        imail = sub_create(self.portal["incoming-mail"], "dmsincomingmail", datetime.now(), "imm2")
+        imfile = createContentInContainer(imail, "dmsmainfile", id="imf2")
+        elements = getattr(imfile.aq_parent, "categorized_elements", None)
+        if elements and imfile.UID() in elements:
+            del elements[imfile.UID()]
+        v = self._info_viewlet(imfile)
+        self.assertIsNone(v.element)
+        self.assertEqual(v.render(), "")
+
+    def test_item_info_viewlet_approved_hidden_without_approvers(self):
+        """The approved icon is hidden when no approver is configured for the
+        mail, mirroring OMVersionsTable.setUpColumns dropping the ApprovedColumn."""
+        self.change_user("siteadmin")
+        intids = getUtility(IIntIds)
+        params = {
+            "title": u"Sans approbation",
+            "internal_reference_no": internalReferenceOutgoingMailDefaultValue(
+                DummyView(self.portal, self.portal.REQUEST)
+            ),
+            "mail_type": "courrier",
+            "treating_groups": self.portal["contacts"]["plonegroup-organization"][
+                "direction-generale"
+            ]["grh"].UID(),
+            "recipients": [RelationValue(intids.getId(self.portal["contacts"]["jeancourant"]))],
+            "assigned_user": "agent",
+            "sender": self.portal["contacts"]["jeancourant"]["agent-electrabel"].UID(),
+            "send_modes": u"post",
+            "signers": [],
+            "esign": True,
+        }
+        omail3 = sub_create(self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "om3", **params)
+        ct = self.portal["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"]
+        filename = u"Réponse salle.odt"
+        with open("%s/batchimport/toprocess/outgoing-mail/%s" % (PRODUCT_DIR, filename), "rb") as fo:
+            file_object = NamedBlobFile(fo.read(), filename=filename)
+            file3 = createContentInContainer(
+                omail3,
+                "dmsommainfile",
+                id="file3",
+                scan_id="012999900000699",
+                file=file_object,
+                content_category=calculate_category_id(ct),
+            )
+        self.assertEqual(IOMApproval(omail3).approvers, [])
+        el = omail3.categorized_elements[file3.UID()]
+        el["approved_activated"] = True  # the category-group option is on...
+        # ... so the base viewlet would display the approval icon
+        self.assertTrue(CategorizedItemInfoViewlet(file3, self.portal.REQUEST, None, None).show(el, "approved"))
+        # ... but the dms viewlet hides it because no approver is configured
+        self.assertFalse(self._info_viewlet(file3).show(el, "approved"))


### PR DESCRIPTION
## Summary
Displays the category status icons below a categorized item's title, reusing the new base viewlet from
collective.iconifiedcategory. Outgoing-mail (OM) files get the **rich Approved/Signed workflow states**
(same visuals and alt text as the OM version table), rendered **non-clickable** and with the
"(click to …)" hints stripped. Incoming-mail files and annexes fall back to the base display icons.

Key changes:
- Shared OM state helpers in `browser/iconified_category.py` (one source of truth for the table columns
  and the viewlet; asserted column strings unchanged).
- `DmsCategorizedItemInfoViewlet` in `browser/viewlets.py` overriding the base `approved` / `signed` seams,
  guarded on `IImioDmsOutgoingMail`.
- `browser/overrides.zcml`: unconfigure + re-register the base viewlet, reusing the base template via
  `<configure package="collective.iconifiedcategory">` (no duplicated `.pt`).
- CSS generalization in `skins/imio_dms_mail/imiodmsmail.css.dtml` for the viewlet's `div.categorized_elements_details` context.
- Tests + `CHANGES.rst`.

## Ticket
PARAF-412 — https://support-imio.atlassian.net/browse/PARAF-412

## Depends on
- collective.iconifiedcategory#30 (base viewlet + extensibility seams). Merge that first.

## Pre-PR checks
- [x] CHANGES up to date
- [x] Tests exist for new code
- [x] Diff matches ticket
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (N/A — skins/browser only)
- [x] Commits reference ticket / mergeable

## Commits
- 1a17b95d PARAF-412: Displayed iconified icons below outgoing files title
