### PR TITLE
PARAF-483: Improved "Approb." and "Signed" icons behavior and validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changelog
   [chris-adam]
 - Considered seal when checking if a signer is defined on a sub/template.
   [sgeulette]
+- Improved "Approb." and "Signed" icons behavior and validation (PARAF-483).
+  [chris-adam]
 
 3.1.5 (2026-06-19)
 ------------------

--- a/imio/dms/mail/adapters.py
+++ b/imio/dms/mail/adapters.py
@@ -1236,6 +1236,20 @@ class OMApprovalAdapter(object):
             approvers = approvers.union(set(i_approvers))
         return list(approvers)
 
+    def is_file_eligible(self, file_obj):
+        """Whether a file should be approved: it is to_sign, this mail has approvers, and it is
+        not exempt (a pdf conversion or a mailing file, which may be signed without approval).
+
+        Single source of truth shared by ``_correct_to_approve`` (setter) and
+        ``ImioDmsOutgoingMail.invalid_sign_approve_files`` (checker) so they cannot drift.
+        """
+        return bool(
+            getattr(file_obj, "to_sign", False)
+            and self.approvers
+            and not base_hasattr(file_obj, "conv_from_uid")
+            and not getattr(file_obj, "need_mailing", False)
+        )
+
     @property
     def current_nb(self):
         """Return the current store approbal number."""

--- a/imio/dms/mail/browser/iconified_category.py
+++ b/imio/dms/mail/browser/iconified_category.py
@@ -32,6 +32,26 @@ from zope.i18n import translate
 """  # noqa
 
 
+def _add_client_hints(json_resp, view):
+    """Append client-side action hints to the JSON response.
+
+    ``reload`` -> full page reload
+    ``refresh_context_messages`` -> AJAX-refresh the context messages
+    """
+    if getattr(view, "reload", False):
+        hints = ['"reload": true']
+    else:
+        hints = []
+        if getattr(view, "refresh_context_messages", False):
+            hints.append('"refresh_context_messages": true')
+    if not hints:
+        return json_resp
+    resp = json_resp.rstrip()
+    if resp.endswith("}"):
+        return resp[:-1] + "," + ",".join(hints) + "}"
+    return json_resp
+
+
 class ApprovedColumn(BaseApprovedColumn):
 
     def __init__(self, context, request, table):
@@ -59,7 +79,7 @@ class ApprovedColumn(BaseApprovedColumn):
         if self.approval.is_state_before_approve(state=state):  # state < to_approve
             # to-approve class is used when state is prior to to_approve
             if self.is_deactivated(content):  # to_approve is False
-                if (not self.approval.approvers or not content.to_sign or not editable or  # noqa W504
+                if (not self.approval.approvers or not editable or  # noqa W504
                         need_mailing_value(document=content.getObject())):
                     self.msg = u"Deactivated for approval"
                     return " to-approve "
@@ -132,8 +152,9 @@ class ApprovedChangeView(BaseApprovedChangeView):
         self.approval = OMApprovalAdapter(self.parent)
         self.uid = self.context.UID()
         self.msg = u""
-        self.reload = False
+        self.reload = False  # full page reload
         self.could_reload = False
+        self.refresh_context_messages = False  # AJAX: refresh the warning banner
 
     @property
     def p_state(self):
@@ -216,20 +237,18 @@ class ApprovedChangeView(BaseApprovedChangeView):
         status, values = self._get_next_values(old_values)
         super(BaseApprovedChangeView, self).set_values(values)
         if self.could_reload:
-            # new_approval_status = self.parent.has_approvings()
-            new_approval_status = self.parent.has_approvings()
-            if old_approval_status != new_approval_status:
+            if old_approval_status != self.parent.has_approvings():
                 cache_chooser = getUtility(ICacheChooser)
                 the_cache = cache_chooser("imio.dms.mail.browser.actionspanel.DmsOMActionsPanelView__call__")
                 the_cache.ramcache.invalidate("imio.dms.mail.browser.actionspanel.DmsOMActionsPanelView__call__")
                 self.reload = True
+            else:
+                self.refresh_context_messages = True
         return status, self.msg
 
     def __call__(self):
         json_resp = super(ApprovedChangeView, self).__call__()
-        if self.reload and json_resp.rstrip().endswith("}"):
-            json_resp = json_resp.rstrip()[:-1] + ',"reload": true}'
-        return json_resp
+        return _add_client_hints(json_resp, self)
 
 
 class SignedColumn(BaseSignedColumn):
@@ -256,8 +275,7 @@ class SignedColumn(BaseSignedColumn):
                     return " deactivated "
                 else:
                     return " deactivated editable"
-            # we don't want to unset to_sign if to_approve is True
-            elif editable and (not content.to_sign or not content.to_approve):
+            elif editable:
                 return " editable"
             else:
                 return ""
@@ -265,7 +283,7 @@ class SignedColumn(BaseSignedColumn):
             return " deactivated"
         else:  # state >= to_approve and to_sign is True
             base_css = self.is_active(content) and ' active' or ''  # signed is True ?
-            if av.p_state in ("to_be_signed", "signed"):
+            if av.p_state == "to_be_signed":
                 # we don't want to unset to_sign if to_approve is True
                 if editable and (not content.to_sign or not content.to_approve):
                     return '{0} editable'.format(base_css)
@@ -288,6 +306,7 @@ class SignedChangeView(BaseSignedChangeView):
         super(SignedChangeView, self).__init__(context, request)
         self.parent = self.context.__parent__
         self.reload = False
+        self.refresh_context_messages = False
 
     @property
     def p_state(self):
@@ -310,7 +329,7 @@ class SignedChangeView(BaseSignedChangeView):
                 values['signed'] = False
                 status = -1
 #                esign_audit("disable_to_sign", "mail={} file={}".format(self.parent.UID(), self.context.UID()))
-            self.reload = True
+            self.refresh_context_messages = True
         elif old_values['to_sign'] and self.p_state in ("to_be_signed", "signed"):
             if old_values['signed'] is False:
                 values['to_sign'] = True
@@ -332,6 +351,4 @@ class SignedChangeView(BaseSignedChangeView):
 
     def __call__(self):
         json_resp = super(SignedChangeView, self).__call__()
-        if self.reload and json_resp.rstrip().endswith("}"):
-            json_resp = json_resp.rstrip()[:-1] + ',"reload": true}'
-        return json_resp
+        return _add_client_hints(json_resp, self)

--- a/imio/dms/mail/browser/static/outgoingmail.js
+++ b/imio/dms/mail/browser/static/outgoingmail.js
@@ -13,3 +13,38 @@ $(document).ready(function(){
       window.alert("Erreur au rafraichissement automatique");
     }*/
 });
+
+
+// Update the sign/approve icons and the invalid-combination warning banner.
+// Rebinds the click bound by collective.iconifiedcategory/iconifiedcategory.js.
+$(document).ready(function(){
+    setTimeout(function() {
+    $('a.iconified-action').off('click').on('click', function() {
+      var obj = $(this);
+      if (!obj.hasClass('editable')) { return false; }
+      var values = {'iconified-value': !obj.hasClass('active')};
+      $.getJSON(obj.attr('href'), values, function(data) {
+        if (data.reload) {  // approval transition happened: full reload
+          window.location.reload();
+          return;
+        }
+        // update only the clicked icon (same rules as the base handler)
+        if (data.status == 0) {
+          obj.removeClass('active').removeClass('deactivated').removeClass('error');
+        } else if (data.status == 1) {
+          obj.addClass('active').removeClass('deactivated').removeClass('error');
+        } else if (data.status == -1) {
+          obj.removeClass('active').addClass('deactivated').removeClass('error');
+        } else {
+          obj.addClass('error');
+        }
+        obj.attr('alt', data.msg).attr('title', data.msg);
+        // AJAX-refresh the invalid-combination warning banner (always-present wrapper)
+        if (data.refresh_context_messages) {
+          $('#dms-context-messages').load(location.href + ' #dms-context-messages > *');
+        }
+      });
+      return false;
+    });
+    }, 0);
+});

--- a/imio/dms/mail/browser/viewlets.py
+++ b/imio/dms/mail/browser/viewlets.py
@@ -19,6 +19,7 @@ from imio.prettylink.interfaces import IPrettyLink
 from plone import api
 from plone.app.layout.viewlets import ViewletBase
 from plone.app.layout.viewlets.common import FooterViewlet
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
@@ -108,7 +109,23 @@ class ContextInformationViewlet(GlobalMessagesViewlet):
     """
 
     def getAllMessages(self):
-        """Check if an address field is empty"""
+        """Warn about incomplete recipient addresses and invalid sign/approve combinations."""
+        ret = []
+        # invalid to_sign/to_approve combination on an outgoing mail with approvers
+        if IImioDmsOutgoingMail.providedBy(self.context):
+            for afile in self.context.invalid_sign_approve_files():
+                msg = translate(
+                    u"The file '${title}' has an invalid signature/approval combination: "
+                    u"a file to be signed must also be approved, and vice versa.",
+                    domain="imio.dms.mail",
+                    context=self.request,
+                    mapping={"title": safe_unicode(afile.Title())},
+                )
+                ret.append(
+                    PseudoMessage(msg_type="significant", text=richtextval(msg),
+                                  hidden_uid=generate_uid(), can_hide=False)
+                )
+        # incomplete recipient/contact address fields
         if IContactContent.providedBy(self.context):
             contacts = [self.context]
         elif IImioDmsOutgoingMail.providedBy(self.context):
@@ -116,8 +133,8 @@ class ContextInformationViewlet(GlobalMessagesViewlet):
             for rv in self.context.recipients or []:
                 if not rv.isBroken() and rv.to_path:
                     contacts.append(self.context.restrictedTraverse(rv.to_path))
-        if not contacts:
-            return []
+        else:
+            contacts = []
         errors = []
         for contact in contacts:
             address = get_address(contact)
@@ -133,7 +150,6 @@ class ContextInformationViewlet(GlobalMessagesViewlet):
             if empty_keys:
                 errors.append((contact, empty_keys))
 
-        ret = []
         for (contact, keys) in errors:
             msg = translate(
                 u"This contact '${title}' has missing address fields: ${keys}",
@@ -148,6 +164,13 @@ class ContextInformationViewlet(GlobalMessagesViewlet):
                 PseudoMessage(msg_type="significant", text=richtextval(msg), hidden_uid=generate_uid(), can_hide=False)
             )
         return ret
+
+    def render(self):
+        # Wrap in an always-present container so the banner can be AJAX-refreshed
+        # (via jQuery .load) even when there is currently no message.
+        return u'<div id="dms-context-messages">{0}</div>'.format(
+            super(ContextInformationViewlet, self).render()
+        )
 
 
 class CKBatchActionsViewlet(BatchActionsViewlet):

--- a/imio/dms/mail/dmsmail.py
+++ b/imio/dms/mail/dmsmail.py
@@ -889,6 +889,17 @@ class ImioDmsOutgoingMail(DmsOutgoingMail):
         else:  # has approvals and all done
             return approval.current_nb == -1
 
+    def invalid_sign_approve_files(self):
+        """Return child files whose (to_sign, to_approve) combination is invalid."""
+        approval = IOMApproval(self)
+        if not approval.approvers:
+            return []
+        return [
+            f for f in self.objectValues()
+            if f.portal_type in ("dmsommainfile", "dmsappendixfile")
+            and bool(getattr(f, "to_approve", False)) != approval.is_file_eligible(f)
+        ]
+
     def wf_conditions(self):
         """Returns the adapter providing workflow conditions"""
         return IImioDmsOutgoingMailWfConditions(self)

--- a/imio/dms/mail/subscribers.py
+++ b/imio/dms/mail/subscribers.py
@@ -414,6 +414,23 @@ def dmsincomingmail_transition(mail, event):
             mail.portal_catalog.reindexObject(mail, ["assigned_user"], update_metadata=0)
 
 
+def dmsoutgoingmail_before_transition(mail, event):
+    """
+    Block entering the approval/signing process while a file has an invalid sign/approve
+    combination. Both entry transitions are guarded: ``propose_to_approve`` and ``propose_to_be_signed``.
+    """
+    if event.transition and event.transition.id in ("propose_to_approve", "propose_to_be_signed"):
+        invalid = mail.invalid_sign_approve_files()
+        if invalid:
+            raise Invalid(
+                _(
+                    u"The following file(s) have an invalid signature/approval combination "
+                    u"(a file to be signed must also be approved, and vice versa): ${files}.",
+                    mapping={"files": u", ".join(safe_unicode(f.Title()) for f in invalid)},
+                )
+            )
+
+
 def dmsoutgoingmail_transition(mail, event):
     """When closing an outgoing mail, add the outgoing_date if necessary."""
     if event.transition and event.transition.id == "mark_as_sent" and mail.outgoing_date is None:
@@ -744,26 +761,16 @@ def _correct_to_sign(file_obj):
 
 def _correct_to_approve(file_obj):
     """Correct to_approve value following context.
-    Force from True to False except if:
-    * to_sign is True
-    * approvers are defined on parent om
-    * file is not a pdf conversion
-    * file doesn't need_mailing
-    Then the file is added to the approval process.
+    Keep True only if the file is approval-eligible (to_sign, approvers defined, not a pdf
+    conversion, no mailing -- see OMApprovalAdapter.is_file_eligible), then add it to the approval
+    process; otherwise force to False.
     """
     # handle to_approve attribute
     orig_value = getattr(file_obj, "to_approve", False)
-    new_value = False
     om_obj = file_obj.__parent__
     approval = OMApprovalAdapter(om_obj)
-    if (
-        orig_value
-        and getattr(file_obj, "to_sign", False)
-        and approval.approvers
-        and not base_hasattr(file_obj, "conv_from_uid")
-        and not getattr(file_obj, "need_mailing", False)
-    ):
-        new_value = True
+    new_value = bool(orig_value and approval.is_file_eligible(file_obj))
+    if new_value:
         approval.add_file_to_approval(file_obj.UID())
     if orig_value != new_value:  # only when passing from True to False normally
         file_obj.to_approve = new_value

--- a/imio/dms/mail/subscribers.zcml
+++ b/imio/dms/mail/subscribers.zcml
@@ -94,6 +94,11 @@
     <!-- IImioDmsOutgoingMail -->
     <subscriber
         for="imio.dms.mail.dmsmail.IImioDmsOutgoingMail
+             Products.DCWorkflow.interfaces.IBeforeTransitionEvent"
+        handler=".subscribers.dmsoutgoingmail_before_transition"
+      />
+    <subscriber
+        for="imio.dms.mail.dmsmail.IImioDmsOutgoingMail
              Products.DCWorkflow.interfaces.IAfterTransitionEvent"
         handler=".subscribers.dmsoutgoingmail_transition"
       />

--- a/imio/dms/mail/tests/test_adapters.py
+++ b/imio/dms/mail/tests/test_adapters.py
@@ -618,6 +618,32 @@ class TestOMApprovalAdapter(unittest.TestCase, ImioTestHelpers):
         self.assertIsNone(self.approval.get_approver_nb("agent"))
         self.assertIsNone(self.approval.get_approver_nb("unknown"))
 
+    def test_is_file_eligible(self):
+        """A file is approval-eligible only when to_sign, the mail has approvers, and it is
+        neither a pdf conversion nor a mailing file."""
+        f = self.files[0]
+        self.assertTrue(self.approval.approvers)
+        # to_sign + approvers + not conversion + not mailing => eligible
+        f.to_sign = True
+        self.assertTrue(self.approval.is_file_eligible(f))
+        # not to_sign => not eligible
+        f.to_sign = False
+        self.assertFalse(self.approval.is_file_eligible(f))
+        # exempt: pdf conversion (has conv_from_uid)
+        f.to_sign = True
+        f.conv_from_uid = "some-source-uid"
+        self.assertFalse(self.approval.is_file_eligible(f))
+        del f.conv_from_uid
+        # exempt: mailing file
+        f.need_mailing = True
+        self.assertFalse(self.approval.is_file_eligible(f))
+        f.need_mailing = False
+        self.assertTrue(self.approval.is_file_eligible(f))
+        # no approvers => never eligible
+        self.approval.reset()
+        self.assertFalse(self.approval.approvers)
+        self.assertFalse(self.approval.is_file_eligible(f))
+
     def test_roles(self):
         # Empty, no approval session started
         self.assertEqual(self.approval.roles, {})

--- a/imio/dms/mail/tests/test_browser_iconified_category.py
+++ b/imio/dms/mail/tests/test_browser_iconified_category.py
@@ -5,6 +5,7 @@ from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import datetime
 from imio.dms.mail import PRODUCT_DIR
 from imio.dms.mail.adapters import OMApprovalAdapter
+from imio.dms.mail.browser.iconified_category import _add_client_hints
 from imio.dms.mail.browser.iconified_category import ApprovedChangeView
 from imio.dms.mail.browser.iconified_category import ApprovedColumn
 from imio.dms.mail.browser.iconified_category import SignedChangeView
@@ -138,7 +139,9 @@ class TestBrowserIconifiedCategory(unittest.TestCase, ImioTestHelpers):
         file2_cc = CategorizedContent(self.omail2, uuidToCatalogBrain(self.file2.UID()))
         col = ApprovedColumn(self.omail2, self.portal.REQUEST, None)
         # "created", nothing to approve
-        col.get_action_view(file2_cc)()  # deactivate approval on file2
+        resp = col.get_action_view(file2_cc)()  # deactivate approval on file2
+        # has_approvings() flips True->False => transitions change => full reload
+        self.assertIn('"reload": true', resp)
         # file2_brain = get_brain(self.file2)
         self.change_user("dirg")
         self.assertEqual(col.css_class(file2_cc), " to-approve ")
@@ -146,8 +149,16 @@ class TestBrowserIconifiedCategory(unittest.TestCase, ImioTestHelpers):
         self.change_user("agent")
         self.assertEqual(col.css_class(file2_cc), " to-approve editable")
         self.assertEqual(col.msg, u"Deactivated for approval (click to activate)")
+        SignedChangeView(self.file2, self.portal.REQUEST)()  # file2 -> not to_sign
+        file2_cc = CategorizedContent(self.omail2, uuidToCatalogBrain(self.file2.UID()))
+        self.assertEqual(col.css_class(file2_cc), " to-approve editable")
+        self.assertEqual(col.msg, u"Deactivated for approval (click to activate)")
+        SignedChangeView(self.file2, self.portal.REQUEST)()  # restore to_sign
+        file2_cc = CategorizedContent(self.omail2, uuidToCatalogBrain(self.file2.UID()))
         # "created", one file to approve
-        col.get_action_view(file2_cc)()  # activate approval on file2
+        resp = col.get_action_view(file2_cc)()  # activate approval on file2
+        # re-activating flips has_approvings False->True => transitions change => full reload
+        self.assertIn('"reload": true', resp)
         # file2_brain = get_brain(self.file2)
         self.change_user("dirg")
         self.assertEqual(col.css_class(file2_cc), " active to-approve")
@@ -291,12 +302,12 @@ class TestBrowserIconifiedCategory(unittest.TestCase, ImioTestHelpers):
         self.change_user("dirg")
         self.assertEqual(col.css_class(file2_cc), "")
         self.change_user("agent")
-        self.assertEqual(col.css_class(file2_cc), "")
+        self.assertEqual(col.css_class(file2_cc), " editable")
         ApprovedChangeView(file3, self.portal.REQUEST)()  # Set file3 not to_approve
         self.assertEqual(col.css_class(file3_cc), " editable")
         self.assertEqual(
             col.get_action_view(file3_cc)(),
-            u'{"msg":"Cet élément ne doit pas être signé","status":-1,"reload": true}',
+            u'{"msg":"Cet élément ne doit pas être signé","status":-1,"refresh_context_messages": true}',
         )  # Set file3 not to_sign
         self.assertEqual(col.css_class(file3_cc), " deactivated editable")
         self.change_user("dirg")
@@ -327,10 +338,36 @@ class TestBrowserIconifiedCategory(unittest.TestCase, ImioTestHelpers):
         )  # Set file2 as signed
         file2_cc = CategorizedContent(self.omail2, uuidToCatalogBrain(self.file2.UID()))  # reload metadata
         self.assertEqual(col.css_class(file2_cc), " active")
+        # "signed"
+        self.change_user("encodeur")
+        self.pw.doActionFor(self.omail2, "mark_as_signed")
+        self.assertEqual(api.content.get_state(self.omail2), "signed")
+        file2_cc = CategorizedContent(self.omail2, uuidToCatalogBrain(self.file2.UID()))
+        self.assertEqual(col.css_class(file2_cc), " active")
+        self.assertEqual(col.get_url(file2_cc), "#")
+        self.assertEqual(col.css_class(file3_cc), " deactivated")
         # "sent"
         self.pw.doActionFor(self.omail2, "mark_as_sent")
         self.assertEqual(col.css_class(file2_cc), " active")
         self.assertEqual(col.css_class(file3_cc), " deactivated")
+
+    def test__add_client_hints(self):
+        """_add_client_hints appends the right client-side hint(s) to the JSON response."""
+        view = ApprovedChangeView(self.file1, self.portal.REQUEST)
+        base = u'{"msg":"x","status":0}'
+        # no flag set => response returned unchanged
+        self.assertEqual(_add_client_hints(base, view), base)
+        # refresh_context_messages only
+        view.refresh_context_messages = True
+        self.assertEqual(
+            _add_client_hints(base, view), u'{"msg":"x","status":0,"refresh_context_messages": true}'
+        )
+        # reload takes precedence over refresh_context_messages
+        view.reload = True
+        self.assertEqual(_add_client_hints(base, view), u'{"msg":"x","status":0,"reload": true}')
+        # a flag is set but the response is not a JSON object => returned unchanged
+        view.reload, view.refresh_context_messages = False, True
+        self.assertEqual(_add_client_hints(u"not-json", view), u"not-json")
 
     def test_signed_change_view(self):
         """Test ApprovedChangeView"""

--- a/imio/dms/mail/tests/test_dmsmail.py
+++ b/imio/dms/mail/tests/test_dmsmail.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from collective.contact.plonegroup.config import get_registry_organizations
+from collective.iconifiedcategory.utils import calculate_category_id
 from datetime import datetime
 from imio.dms.mail import AUC_RECORD
 from imio.dms.mail import CONTACTS_PART_SUFFIX
 from imio.dms.mail import CREATING_GROUP_SUFFIX
 from imio.dms.mail import PRODUCT_DIR
+from imio.dms.mail.adapters import OMApprovalAdapter
 from imio.dms.mail.browser.reply_form import ReplyForm
 from imio.dms.mail.browser.task import TaskEdit
 from imio.dms.mail.dmsmail import AssignedUserValidator
@@ -661,3 +663,69 @@ class TestDmsmail(unittest.TestCase, ImioTestHelpers):
         self.assertRaises(Invalid, auv.validate, "agent1")
         # we check assigned_user requirement if the imail state will be changed
         # this test is done in im wfadaptation test
+
+    def test_invalid_sign_approve_files(self):
+        """to_approve must match approval-eligibility when the mail has approvers."""
+        pf = self.portal["contacts"]["personnel-folder"]
+        om = sub_create(
+            self.portal["outgoing-mail"],
+            "dmsoutgoingmail",
+            datetime.now(),
+            "om-inv",
+            title=u"Courrier sortant test",
+            mail_type="courrier",
+            treating_groups=self.pgof["direction-generale"]["grh"].UID(),
+            sender=self.portal["contacts"]["jeancourant"]["agent-electrabel"].UID(),
+            send_modes=u"post",
+            signers=[
+                {
+                    "number": 1,
+                    "signer": pf["dirg"]["directeur-general"].UID(),
+                    "approvings": [u"_themself_"],
+                    "editor": True,
+                }
+            ],
+        )
+        ct = self.portal["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"]
+        with open("%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR, "rb") as fo:
+            f = createContentInContainer(
+                om,
+                "dmsommainfile",
+                id="file1",
+                scan_id="012999900000600",
+                file=NamedBlobFile(fo.read(), filename=u"Réponse salle.odt"),
+                content_category=calculate_category_id(ct),
+            )
+        self.assertTrue(OMApprovalAdapter(om).approvers)
+        # both True / both False => valid
+        f.to_sign, f.to_approve = True, True
+        self.assertEqual(om.invalid_sign_approve_files(), [])
+        f.to_sign, f.to_approve = False, False
+        self.assertEqual(om.invalid_sign_approve_files(), [])
+        # eligible file to_sign without to_approve => invalid
+        f.to_sign, f.to_approve = True, False
+        self.assertEqual(om.invalid_sign_approve_files(), [f])
+        # to_approve without to_sign => invalid
+        f.to_sign, f.to_approve = False, True
+        self.assertEqual(om.invalid_sign_approve_files(), [f])
+        # exempt (mailing / pdf conversion) may be to_sign without to_approve => valid
+        f.to_sign, f.to_approve, f.need_mailing = True, False, True
+        self.assertEqual(om.invalid_sign_approve_files(), [])
+        f.need_mailing = False
+        f.conv_from_uid = "some-source-uid"
+        self.assertEqual(om.invalid_sign_approve_files(), [])
+        del f.conv_from_uid
+        # no approvers => never invalid (Approb. column is hidden anyway)
+        om2 = sub_create(self.portal["outgoing-mail"], "dmsoutgoingmail", datetime.now(), "noappr")
+        with open("%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR, "rb") as fo:
+            f2 = createContentInContainer(
+                om2,
+                "dmsommainfile",
+                id="f2",
+                scan_id="012999900000700",
+                file=NamedBlobFile(fo.read(), filename=u"Réponse salle.odt"),
+                content_category=calculate_category_id(ct),
+            )
+        f2.to_sign, f2.to_approve = True, False  # would be invalid if approvers existed
+        self.assertFalse(OMApprovalAdapter(om2).approvers)
+        self.assertEqual(om2.invalid_sign_approve_files(), [])

--- a/imio/dms/mail/tests/test_subscribers.py
+++ b/imio/dms/mail/tests/test_subscribers.py
@@ -35,6 +35,7 @@ from plone.app.testing import TEST_USER_ID
 from plone.app.users.browser.personalpreferences import UserDataConfiglet
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile.file import NamedBlobFile
+from Products.CMFPlone.utils import safe_unicode
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.relationfield import RelationValue
 from zExceptions import Redirect
@@ -1353,6 +1354,46 @@ class TestSubscribers(unittest.TestCase, ImioTestHelpers):
         approval.approve_file(files[1], "dirg", transition="propose_to_be_signed")
         approval.approve_file(files[1], "bourgmestre", transition="propose_to_be_signed")
         approval.approve_file(files[0], "bourgmestre", transition="propose_to_be_signed")
+
+    def test_dmsoutgoingmail_before_transition(self):
+        """Both entry transitions (propose_to_approve / propose_to_be_signed) raise Invalid while a
+        file has an invalid sign/approve combination; other transitions are never blocked; and the
+        process proceeds once every file is valid again."""
+        omail, files, approval = self._setup_omail_with_esign()
+        pw = self.portal.portal_workflow
+        # two invalid combinations: eligible-but-not-approved, and approved-but-not-to_sign
+        files[0].to_sign, files[0].to_approve = True, False
+        files[1].to_sign, files[1].to_approve = False, True
+        invalid = omail.invalid_sign_approve_files()
+        self.assertIn(files[0], invalid)
+        self.assertIn(files[1], invalid)
+        with self.assertRaises(Invalid) as cm:
+            pw.doActionFor(omail, "propose_to_approve")
+        self.assertEqual(api.content.get_state(omail), "created")  # raised before state change
+        # the raised message lists every invalid file
+        files_listed = cm.exception.args[0].mapping["files"]
+        self.assertIn(safe_unicode(files[0].Title()), files_listed)
+        self.assertEqual(files_listed.count(u", ") + 1, len(invalid))
+        # make every file valid (to_approve must match eligibility) => transition proceeds
+        for f in omail.invalid_sign_approve_files():
+            f.to_approve = approval.is_file_eligible(f)
+        self.assertEqual(omail.invalid_sign_approve_files(), [])
+        pw.doActionFor(omail, "propose_to_approve")
+        self.assertEqual(api.content.get_state(omail), "to_approve")
+        # the guard covers only the two transitions: an invalid combo blocks nothing else
+        files[0].to_sign, files[0].to_approve = True, False
+        self.assertIn(files[0], omail.invalid_sign_approve_files())
+        pw.doActionFor(omail, "back_to_creation")
+        self.assertEqual(api.content.get_state(omail), "created")
+        # "propose_to_be_signed" must be blocked.
+        for f in files:
+            approval.remove_file_from_approval(f.UID())
+        files[1].to_sign, files[1].to_approve = False, False  # keep files[1] valid
+        self.assertFalse(omail.has_approvings())
+        self.assertEqual(omail.invalid_sign_approve_files(), [files[0]])
+        with self.assertRaises(Invalid):
+            pw.doActionFor(omail, "propose_to_be_signed")
+        self.assertEqual(api.content.get_state(omail), "created")
 
     def test_i_annex_removed_pdf_file(self):
         """Test i_annex_removed Case 1: removing a generated PDF removes it from approval."""

--- a/imio/dms/mail/tests/test_viewlets.py
+++ b/imio/dms/mail/tests/test_viewlets.py
@@ -1,13 +1,19 @@
 # -*- coding: utf-8 -*-
 """Test views."""
+from collective.iconifiedcategory.utils import calculate_category_id
 from collective.messagesviewlet.message import PseudoMessage
+from datetime import datetime
+from imio.dms.mail import PRODUCT_DIR
 from imio.dms.mail.browser.viewlets import ContactContentBackrefsViewlet
 from imio.dms.mail.browser.viewlets import ContextInformationViewlet
 from imio.dms.mail.dmsmail import IImioDmsIncomingMail
 from imio.dms.mail.testing import DMSMAIL_INTEGRATION_TESTING
+from imio.dms.mail.utils import sub_create
 from imio.helpers.content import get_object
 from plone import api
 from plone.app.testing import login
+from plone.dexterity.utils import createContentInContainer
+from plone.namedfile.file import NamedBlobFile
 
 import unittest
 
@@ -108,3 +114,42 @@ class TestContactContentBackrefsViewlet(unittest.TestCase):
         self.assertEqual(len(sorg_v.getAllMessages()), 1)  # suborganization has missing street too
         self.assertEqual(len(hp_v.getAllMessages()), 1)  # held position has missing street too
         self.assertEqual(len(om_v.getAllMessages()), 1)  # outgoing mail has missing street too
+        # outgoing mail with approvers + an invalid sign/approve combination => warning banner
+        login(self.portal, "siteadmin")
+        pf = self.portal["contacts"]["personnel-folder"]
+        om = sub_create(
+            self.portal["outgoing-mail"],
+            "dmsoutgoingmail",
+            datetime.now(),
+            "om-viewlet",
+            title=u"Courrier sortant test",
+            mail_type="courrier",
+            treating_groups=self.portal["contacts"]["plonegroup-organization"]["direction-generale"]["grh"].UID(),
+            sender=self.portal["contacts"]["jeancourant"]["agent-electrabel"].UID(),
+            send_modes=u"post",
+            signers=[
+                {"number": 1, "signer": pf["dirg"]["directeur-general"].UID(),
+                 "approvings": [u"_themself_"], "editor": True}
+            ],
+        )
+        ct = self.portal["annexes_types"]["outgoing_dms_files"]["outgoing-dms-file"]
+        with open("%s/batchimport/toprocess/outgoing-mail/Réponse salle.odt" % PRODUCT_DIR, "rb") as fo:
+            afile = createContentInContainer(
+                om,
+                "dmsommainfile",
+                id="file1",
+                scan_id="012999900000900",
+                file=NamedBlobFile(fo.read(), filename=u"Réponse salle.odt"),
+                content_category=calculate_category_id(ct),
+            )
+        afile.to_sign, afile.to_approve = True, False  # eligible but not approved => invalid
+        om_inv_v = ContextInformationViewlet(om, self.elec.REQUEST, None)
+        combo = [m for m in om_inv_v.getAllMessages() if u"invalid signature/approval combination" in m.text.output]
+        self.assertEqual(len(combo), 1)
+        self.assertTrue(isinstance(combo[0], PseudoMessage))
+        afile.to_approve = True  # valid combination now => no banner
+        combo = [m for m in om_inv_v.getAllMessages() if u"invalid signature/approval combination" in m.text.output]
+        self.assertEqual(combo, [])
+        # render() wraps the (possibly empty) banner in an AJAX-refreshable container
+        om_inv_v.index = lambda: u"BODY"
+        self.assertEqual(om_inv_v.render(), u'<div id="dms-context-messages">BODY</div>')


### PR DESCRIPTION
## Summary
Fixes PARAF-483: on an outgoing mail that has approvers, a file could be left "to sign" without being "to approve" (or vice versa) — a file to be signed must also be approved. A single source of truth (`OMApprovalAdapter.is_file_eligible`) now backs both the `_correct_to_sign` setter and a new `ImioDmsOutgoingMail.invalid_sign_approve_files()` checker so they cannot drift. A `before_transition` subscriber blocks `propose_to_approve` / `propose_to_be_signed` while any file has an invalid combination, a context warning banner lists the offending files, and the Approb./Signed icons now refresh in place (AJAX) instead of forcing a full page reload.

## Ticket
PARAF-483 — https://support-imio.atlassian.net/browse/PARAF-483

## Pre-PR checks
- [x] CHANGES up to date
- [x] Tests exist for new code
- [x] Diff matches ticket
- [x] No debug leftovers
- [x] No stray files / secrets
- [x] Profile / version bumps (n/a — no profile changes)
- [x] Commits reference ticket / mergeable

## Commits
- f4e04511 PARAF-483: Improved Approb. and Signed icons behavior and validation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter eligibility validation for outgoing mail files in sign/approval flows.
  * Introduced clearer warnings for invalid signature/approval combinations in the context banner.
  * Blocked workflow transitions into approval/signing until affected files are corrected.
  * Updated icon interaction to refresh context messages dynamically (avoids unnecessary full reloads).

* **Bug Fixes**
  * Improved behavior and validation of the “Approb.” and “Signed” icons, including related eligibility/class logic.

* **Tests**
  * Expanded test coverage for file eligibility, banner messaging, iconified JSON hints, and transition blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
